### PR TITLE
Update release workflow

### DIFF
--- a/.github/README.md
+++ b/.github/README.md
@@ -1,0 +1,17 @@
+# GitHub Actions
+
+## [Release Build](workflows/release-build.yml)
+
+This workflow allows you to manually trigger a new release. You can set the new version using the **input field** in the [RELEASE Build](https://github.com/remsfal/remsfal-backend/actions/workflows/release-build.yml) Action.
+
+![Screenshot of version input](https://github.com/remsfal/remsfal-backend/assets/54059879/91bac827-28aa-4129-9570-54b999371bd6)  
+_Screenshot of version input field_
+
+If no version is set, the current version will be incremented by a patch (X.X.1 -> X.X.2).
+
+The pipeline performs the following tasks:
+- Creates a new commit with the updated POM.xml files
+- Tags the commit with the specified version
+- Pushes the build packages to the [GitHub Package Registry](https://github.com/remsfal/remsfal-backend/packages/)
+
+The created [release](https://github.com/remsfal/remsfal-backend/releases) will contain the current source code and the `remsfal-service-runner.jar`.

--- a/.github/README.md
+++ b/.github/README.md
@@ -2,16 +2,17 @@
 
 ## [Release Build](workflows/release-build.yml)
 
-This workflow allows you to manually trigger a new release. You can set the new version using the **input field** in the [RELEASE Build](https://github.com/remsfal/remsfal-backend/actions/workflows/release-build.yml) Action.
+This workflow allows you to manually trigger a new release.  
+
+You can set the new version using the **input field** in the [RELEASE Build](https://github.com/remsfal/remsfal-backend/actions/workflows/release-build.yml) Action.
+If no version is set, the current version will be incremented by a patch (X.X.1 -> X.X.2).
 
 ![Screenshot of version input](https://github.com/remsfal/remsfal-backend/assets/54059879/91bac827-28aa-4129-9570-54b999371bd6)  
 _Screenshot of version input field_
 
-If no version is set, the current version will be incremented by a patch (X.X.1 -> X.X.2).
 
 The pipeline performs the following tasks:
 - Creates a new commit with the updated POM.xml files
 - Tags the commit with the specified version
 - Pushes the build packages to the [GitHub Package Registry](https://github.com/remsfal/remsfal-backend/packages/)
-
-The created [release](https://github.com/remsfal/remsfal-backend/releases) will contain the current source code and the `remsfal-service-runner.jar`.
+- Creates a [release](https://github.com/remsfal/remsfal-backend/releases) which contains the current source code and `remsfal-service-runner.jar`.

--- a/.github/workflows/release-build.yml
+++ b/.github/workflows/release-build.yml
@@ -1,8 +1,12 @@
 name: "RELEASE Build"
 
 on:
-  # Only run this workflow manually from the Actions tab
   workflow_dispatch:
+    inputs:
+      nextRelease:
+        description: 'Next Release Version (leave empty to automatically patch current version)'
+        required: false
+        default: ''
 
 jobs:
   build:
@@ -11,16 +15,61 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v4
+
+      - name: Determine Next Version
+        id: next-version
+        run: |
+          CURRENT_VERSION=$(mvn help:evaluate -Dexpression=project.version -q -DforceStdout)
+          echo "Current project version: $CURRENT_VERSION"
+          if  [ -z "${{ github.event.inputs.nextRelease }}" ]; then
+            # Assumes semantic versioning, increments minor version
+            NEXT_VERSION=$(echo $CURRENT_VERSION | awk -F. '{print $1"."$2"."$3+1}')
+          else
+            NEXT_VERSION="${{ github.event.inputs.nextRelease }}"
+          fi
+          echo "Next version: $NEXT_VERSION"
+          echo "RELEASE_VERSION=$NEXT_VERSION" >> $GITHUB_ENV
+
       - name: Set up JDK 17
         uses: actions/setup-java@v4
         with:
           java-version: '17'
           distribution: 'temurin'
+          server-id: 'github'
+
       - name: Cache Maven packages
         uses: actions/cache@v4
         with:
           path: ~/.m2/repository
           key: ${{ runner.os }}-maven-${{ hashFiles('**/pom.xml') }}
-          restore-keys: ${{ runner.os }}-maven
-      - name: Build with Maven (package)
-        run: mvn --batch-mode --update-snapshots package
+          restore-keys: ${{ runner.os }}-maven  
+
+      - name: Set project version
+        run: mvn versions:set -DnewVersion=${RELEASE_VERSION}
+
+      - name: Build with Maven
+        run: mvn clean install
+
+        
+      - name: Publish to GitHub Packages Apache Maven
+        # Disable tests because they were already run in previous build step
+        run: mvn --batch-mode  deploy -PgithubDeploy -Dmaven.test.skip=true 
+        env:
+          GITHUB_TOKEN: ${{ github.token }} # GITHUB_TOKEN is the default env for the password
+
+      - name: Add & Commit
+        uses: EndBug/add-and-commit@v9.1.4
+        with: 
+          add: '["pom.xml", "remsfal-core/pom.xml", "remsfal-service/pom.xml"]'
+          message: "Release version ${{env.RELEASE_VERSION}}"
+          author_name: "Release Bot"
+          author_email: "info@remsfal.de"
+          tag: "v${{env.RELEASE_VERSION}}"
+  
+      - name: Create Release
+        uses: ncipollo/release-action@v1.14.0
+        with: 
+          artifacts: "remsfal-service/target/remsfal-service-runner.jar"
+          tag: "v${{env.RELEASE_VERSION}}"
+          body: "Release version ${{env.RELEASE_VERSION}}"
+          allowUpdates: true

--- a/pom.xml
+++ b/pom.xml
@@ -53,8 +53,8 @@
         <distributionManagement>
           <repository>
             <id>github</id>
-            <name>GitHub calipee Apache Maven Packages</name>
-            <url>https://maven.pkg.github.com/calipee/remsfal-backend</url>
+            <name>GitHub Remsfal Apache Maven Packages</name>
+            <url>https://maven.pkg.github.com/remsfal/remsfal-backend</url>
           </repository>
         </distributionManagement>
         </profile>

--- a/pom.xml
+++ b/pom.xml
@@ -30,8 +30,8 @@
     <distributionManagement>
       <repository>
         <id>github</id>
-        <name>GitHub Calipee Apache Maven Packages</name>
-        <url>https://maven.pkg.github.com/calipee/remsfal-backend</url>
+        <name>GitHub Remsfal Apache Maven Packages</name>
+        <url>https://maven.pkg.github.com/remsfal/remsfal-backend</url>
       </repository>
     </distributionManagement>
 

--- a/pom.xml
+++ b/pom.xml
@@ -27,14 +27,6 @@
         <url>https://github.com/remsfal/remsfal-backend/issues</url>
     </issueManagement>
 
-    <distributionManagement>
-      <repository>
-        <id>github</id>
-        <name>GitHub Remsfal Apache Maven Packages</name>
-        <url>https://maven.pkg.github.com/remsfal/remsfal-backend</url>
-      </repository>
-    </distributionManagement>
-
     <properties>
         <compiler-plugin.version>3.13.0</compiler-plugin.version>
         <maven.compiler.release>17</maven.compiler.release>

--- a/pom.xml
+++ b/pom.xml
@@ -27,6 +27,14 @@
         <url>https://github.com/remsfal/remsfal-backend/issues</url>
     </issueManagement>
 
+    <distributionManagement>
+      <repository>
+        <id>github</id>
+        <name>GitHub Calipee Apache Maven Packages</name>
+        <url>https://maven.pkg.github.com/calipee/remsfal-backend</url>
+      </repository>
+    </distributionManagement>
+
     <properties>
         <compiler-plugin.version>3.13.0</compiler-plugin.version>
         <maven.compiler.release>17</maven.compiler.release>
@@ -46,6 +54,19 @@
                 de.remsfal.service.entity.dto\**
         </sonar.cpd.exclusions>
     </properties>
+
+    <profiles>
+      <profile>
+        <id>githubDeploy</id>
+        <distributionManagement>
+          <repository>
+            <id>github</id>
+            <name>GitHub calipee Apache Maven Packages</name>
+            <url>https://maven.pkg.github.com/calipee/remsfal-backend</url>
+          </repository>
+        </distributionManagement>
+        </profile>
+    </profiles>
 
     <build>
         <pluginManagement>

--- a/remsfal-core/pom.xml
+++ b/remsfal-core/pom.xml
@@ -6,8 +6,9 @@
 
     <parent>
         <groupId>de.remsfal</groupId>
-        <artifactId>remsfal-backend</artifactId>
+        <artifactId>remsfal-backend</artifactId>    
         <version>1.0.0-SNAPSHOT</version>
+        <relativePath>../pom.xml</relativePath>
     </parent>
 
     <properties>

--- a/remsfal-core/pom.xml
+++ b/remsfal-core/pom.xml
@@ -6,7 +6,7 @@
 
     <parent>
         <groupId>de.remsfal</groupId>
-        <artifactId>remsfal-backend</artifactId>    
+        <artifactId>remsfal-backend</artifactId>
         <version>1.0.0-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>

--- a/remsfal-service/pom.xml
+++ b/remsfal-service/pom.xml
@@ -10,9 +10,9 @@
     <parent>
         <groupId>de.remsfal</groupId>
         <artifactId>remsfal-backend</artifactId>
-        <version>1.0.0-SNAPSHOT</version>
+        <version>1.0.0-SNAPSHOT</version>    
+        <relativePath>../pom.xml</relativePath>
     </parent>
-
 
     <properties>
         <quarkus.version>3.12.0</quarkus.version>


### PR DESCRIPTION
Added a release workflow which can be manually triggered in the actions tab as requested in #34.
It's possible to specify the version for the next release, if no version is given the current version will be incremented by a patch.
![image](https://github.com/remsfal/remsfal-backend/assets/54059879/91bac827-28aa-4129-9570-54b999371bd6)
_Screenshot input version_

During the process a commit will be created, the current version of the packages are uploaded to the Github package registry and a release is created. The `remsfal-service-runner.jar` will be added to the release assets.

![image](https://github.com/remsfal/remsfal-backend/assets/54059879/2ccedb6e-acc0-41e1-95f5-c7be64dadc21)
_Screenshot Release Tab_
![image](https://github.com/remsfal/remsfal-backend/assets/54059879/d89180b6-698f-41fb-832f-968257e8b53b)
_Screenshot Release_

A profile for the deployment on Github is introduced in [pom.xml](https://github.com/calipee/remsfal-backend/blob/e0a8cdf2341132c30841653198f4a03275146304/pom.xml#L50C1-L61C16) the  allow multiple release repositories like Sonatype etc in the future.

I did't know where to document the process of creating a release, do you have any suggestion @astanik ?
I thought the README is maybe not the correct place for it.