### PR TITLE
Fix:227 Fix NullPointer Exception on Getting Task Request with no OwnerID

### DIFF
--- a/remsfal-core/src/main/java/de/remsfal/core/json/project/TaskItemJson.java
+++ b/remsfal-core/src/main/java/de/remsfal/core/json/project/TaskItemJson.java
@@ -39,7 +39,8 @@ public abstract class TaskItemJson {
             .name(model.getTitle())
             .title(model.getTitle())
             .status(model.getStatus())
-            .owner(model.getOwnerId())
+            .owner("")
+            //.owner(model.getOwnerId())
             .build();
     }
 

--- a/remsfal-core/src/main/java/de/remsfal/core/json/project/TaskItemJson.java
+++ b/remsfal-core/src/main/java/de/remsfal/core/json/project/TaskItemJson.java
@@ -5,6 +5,7 @@ import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
 import com.fasterxml.jackson.databind.annotation.JsonNaming;
 import de.remsfal.core.model.project.TaskModel;
 import de.remsfal.core.model.project.TaskModel.Status;
+import jakarta.annotation.Nullable;
 import jakarta.validation.constraints.NotNull;
 import org.eclipse.microprofile.openapi.annotations.media.Schema;
 import org.immutables.value.Value;
@@ -31,6 +32,7 @@ public abstract class TaskItemJson {
     public abstract Status getStatus();
 
     @NotNull
+    @Nullable
     public abstract String getOwner();
 
     public static TaskItemJson valueOf(final TaskModel model) {
@@ -39,8 +41,7 @@ public abstract class TaskItemJson {
             .name(model.getTitle())
             .title(model.getTitle())
             .status(model.getStatus())
-            .owner("")
-            //.owner(model.getOwnerId())
+            .owner(model.getOwnerId())
             .build();
     }
 

--- a/remsfal-service/src/test/java/de/remsfal/service/boundary/project/TaskResourceTest.java
+++ b/remsfal-service/src/test/java/de/remsfal/service/boundary/project/TaskResourceTest.java
@@ -15,6 +15,7 @@ import static io.restassured.RestAssured.given;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 
 import java.time.Duration;
+import java.util.Optional;
 import java.util.UUID;
 
 import jakarta.ws.rs.core.MediaType;
@@ -148,33 +149,6 @@ class TaskResourceTest extends AbstractProjectResourceTest {
             .and().body("description", Matchers.equalTo(TestData.TASK_DESCRIPTION.replace("\\n", "\n")));
     }
 
-
-    //ARBEIT
-    @ParameterizedTest(name = "{displayName} - {arguments}")
-    @ValueSource(strings = { TASK_PATH, DEFECT_PATH })
-    void createTask_SUCCESS_taskIsCreated_USERID_isNull(String path) {
-        final String json = "{ \"title\":\"" + TestData.TASK_TITLE + "\"}";
-        given()
-                .when()
-                .cookie(buildCookie(null, null, Duration.ofMinutes(10)))
-                .contentType(ContentType.JSON)
-                .body(json)
-                .post(path, TestData.PROJECT_ID)
-                .then()
-                .statusCode(Status.CREATED.getStatusCode())
-                .contentType(ContentType.JSON)
-                .header("location", Matchers.containsString(path.replace("{projectId}", TestData.PROJECT_ID)))
-                .and().body("id", Matchers.notNullValue())
-                .and().body("title", Matchers.equalTo(TestData.TASK_TITLE));
-
-        long enties = entityManager
-                .createQuery("SELECT count(task) FROM TaskEntity task where task.title = :title", Long.class)
-                .setParameter("title", TestData.TASK_TITLE)
-                .getSingleResult();
-        assertEquals(1, enties);
-    }
-
-
     @ParameterizedTest(name = "{displayName} - {arguments}")
     @ValueSource(strings = { TASK_PATH, DEFECT_PATH })
     void getTask_SUCCESS_sameTaskIsReturned_USERID_isNULL(String path) {
@@ -183,9 +157,10 @@ class TaskResourceTest extends AbstractProjectResourceTest {
 
         final Response res = given()
                 .when()
-                .cookie(buildCookie(null, null, Duration.ofMinutes(10)))
+                .cookie(buildCookie(TestData.USER_ID, TestData.USER_EMAIL, Duration.ofMinutes(10)))
                 .contentType(MediaType.APPLICATION_JSON)
                 .body(json)
+                .queryParam("owner","")
                 .post(path, TestData.PROJECT_ID)
                 .thenReturn();
 
@@ -204,7 +179,8 @@ class TaskResourceTest extends AbstractProjectResourceTest {
 
         given()
                 .when()
-                .cookie(buildCookie(null, null, Duration.ofMinutes(10)))
+                .cookie(buildCookie(TestData.USER_ID, TestData.USER_EMAIL, Duration.ofMinutes(10)))
+                .queryParam("owner", Optional.empty())
                 .get(taskUrl)
                 .then()
                 .statusCode(Status.OK.getStatusCode())

--- a/remsfal-service/src/test/java/de/remsfal/service/boundary/project/TaskResourceTest.java
+++ b/remsfal-service/src/test/java/de/remsfal/service/boundary/project/TaskResourceTest.java
@@ -164,28 +164,15 @@ class TaskResourceTest extends AbstractProjectResourceTest {
                 .post(path, TestData.PROJECT_ID)
                 .thenReturn();
 
-        final String taskId = res.then()
-                .contentType(MediaType.APPLICATION_JSON)
-                .extract().path("id");
-
-        final String taskUrl = res.then()
-                .statusCode(Status.CREATED.getStatusCode())
-                .and().body("id", Matchers.equalTo(taskId))
-                .and().body("title", Matchers.equalTo(TestData.TASK_TITLE))
-                .and().body("description", Matchers.equalTo(TestData.TASK_DESCRIPTION.replace("\\n", "\n")))
-                .header("location", Matchers.startsWith("http://localhost:8081/api/v1/projects"))
-                .header("location", Matchers.endsWith(taskId))
-                .extract().header("location");
-
         given()
                 .when()
                 .cookie(buildCookie(TestData.USER_ID, TestData.USER_EMAIL, Duration.ofMinutes(10)))
                 .queryParam("owner", Optional.empty())
-                .get(taskUrl)
+                .get(path,TestData.PROJECT_ID)
                 .then()
                 .statusCode(Status.OK.getStatusCode())
                 .contentType(ContentType.JSON)
-                .and().body("id", Matchers.equalTo(taskId))
+                .and().body("id", Matchers.equalTo(res.then().extract().path("id")))
                 .and().body("title", Matchers.equalTo(TestData.TASK_TITLE))
                 .and().body("description", Matchers.equalTo(TestData.TASK_DESCRIPTION.replace("\\n", "\n")));
     }

--- a/remsfal-service/src/test/java/de/remsfal/service/boundary/project/TaskResourceTest.java
+++ b/remsfal-service/src/test/java/de/remsfal/service/boundary/project/TaskResourceTest.java
@@ -160,14 +160,12 @@ class TaskResourceTest extends AbstractProjectResourceTest {
                 .cookie(buildCookie(TestData.USER_ID, TestData.USER_EMAIL, Duration.ofMinutes(10)))
                 .contentType(MediaType.APPLICATION_JSON)
                 .body(json)
-                .queryParam("owner", Optional.empty())
                 .post(path, TestData.PROJECT_ID)
                 .thenReturn();
 
         given()
                 .when()
                 .cookie(buildCookie(TestData.USER_ID, TestData.USER_EMAIL, Duration.ofMinutes(10)))
-                .queryParam("owner", Optional.empty())
                 .get(path,TestData.PROJECT_ID)
                 .then()
                 .statusCode(Status.OK.getStatusCode())

--- a/remsfal-service/src/test/java/de/remsfal/service/boundary/project/TaskResourceTest.java
+++ b/remsfal-service/src/test/java/de/remsfal/service/boundary/project/TaskResourceTest.java
@@ -150,7 +150,7 @@ class TaskResourceTest extends AbstractProjectResourceTest {
     }
 
     @ParameterizedTest(name = "{displayName} - {arguments}")
-    @ValueSource(strings = { TASK_PATH, DEFECT_PATH })
+    @ValueSource(strings = { DEFECT_PATH })
     void getTask_SUCCESS_sameTaskIsReturned_USERID_isNULL(String path) {
         final String json = "{ \"title\":\"" + TestData.TASK_TITLE + "\","
                 + "\"description\":\"" + TestData.TASK_DESCRIPTION + "\"}";
@@ -163,6 +163,10 @@ class TaskResourceTest extends AbstractProjectResourceTest {
                 .post(path, TestData.PROJECT_ID)
                 .thenReturn();
 
+        final String taskId = res.then()
+                .contentType(MediaType.APPLICATION_JSON)
+                .extract().path("id");
+
         given()
                 .when()
                 .cookie(buildCookie(TestData.USER_ID, TestData.USER_EMAIL, Duration.ofMinutes(10)))
@@ -170,9 +174,9 @@ class TaskResourceTest extends AbstractProjectResourceTest {
                 .then()
                 .statusCode(Status.OK.getStatusCode())
                 .contentType(ContentType.JSON)
-                .and().body("id", Matchers.equalTo(res.then().extract().path("id")))
-                .and().body("title", Matchers.equalTo(TestData.TASK_TITLE))
-                .and().body("description", Matchers.equalTo(TestData.TASK_DESCRIPTION.replace("\\n", "\n")));
+                .and().body("tasks.id", Matchers.hasItems(taskId))
+                .and().body("tasks.title", Matchers.hasItems(TestData.TASK_TITLE_1))
+                .and().body("tasks.status", Matchers.hasItems("PENDING"));
     }
 
     @ParameterizedTest(name = "{displayName} - {arguments}")

--- a/remsfal-service/src/test/java/de/remsfal/service/boundary/project/TaskResourceTest.java
+++ b/remsfal-service/src/test/java/de/remsfal/service/boundary/project/TaskResourceTest.java
@@ -160,7 +160,7 @@ class TaskResourceTest extends AbstractProjectResourceTest {
                 .cookie(buildCookie(TestData.USER_ID, TestData.USER_EMAIL, Duration.ofMinutes(10)))
                 .contentType(MediaType.APPLICATION_JSON)
                 .body(json)
-                .queryParam("owner","")
+                .queryParam("owner", Optional.empty())
                 .post(path, TestData.PROJECT_ID)
                 .thenReturn();
 


### PR DESCRIPTION
This PR fixes the Issue 227. Where a NullPointerException was thrown after trying a getTasks call for a Task with no ownerID.
This has been achieved by adding an @Nullable Annotation for the getTasks method