### PR TITLE
Cookie TTL Extentsion via ContainerResponseFilter ((#36)[https://github.com/remsfal/remsfal-backend/issues/36])

### DIFF
--- a/remsfal-service/src/main/java/de/remsfal/service/boundary/authentication/HeaderExtensionResponseFilter.java
+++ b/remsfal-service/src/main/java/de/remsfal/service/boundary/authentication/HeaderExtensionResponseFilter.java
@@ -1,0 +1,43 @@
+package de.remsfal.service.boundary.authentication;
+
+import jakarta.annotation.Priority;
+import jakarta.inject.Inject;
+import jakarta.ws.rs.Priorities;
+import jakarta.ws.rs.container.ContainerRequestContext;
+import jakarta.ws.rs.container.ContainerResponseContext;
+import jakarta.ws.rs.container.ContainerResponseFilter;
+import jakarta.ws.rs.core.Cookie;
+import jakarta.ws.rs.ext.Provider;
+import org.jboss.logging.Logger;
+
+
+@Provider
+@Priority(Priorities.HEADER_DECORATOR + 1)
+public class HeaderExtensionResponseFilter  implements ContainerResponseFilter {
+
+    @Inject
+    SessionManager sessionManager;
+
+    @Inject
+    Logger logger;
+
+    @Override
+    public void filter(ContainerRequestContext requestContext,
+                       ContainerResponseContext responseContext) {
+        try{
+            final Cookie sessionCookie = sessionManager.findSessionCookie(requestContext.getCookies());
+            if (sessionCookie != null) {
+                SessionInfo sessionInfo = sessionManager.decryptSessionCookie(sessionCookie);
+
+                if (sessionInfo != null && sessionInfo.isValid()) {
+                    if (sessionInfo.shouldRenew()) {
+                        Cookie newSessionCookie = sessionManager.renewSessionCookie(sessionInfo);
+                        responseContext.getHeaders().add("Set-Cookie", newSessionCookie.getValue());
+                    }
+                }
+            }
+        } catch (Exception e) {
+            logger.error("Error in HeaderExtensionResponseFilter: " + e.getMessage());
+        }
+    }
+}

--- a/remsfal-service/src/main/java/de/remsfal/service/boundary/authentication/SessionInfo.java
+++ b/remsfal-service/src/main/java/de/remsfal/service/boundary/authentication/SessionInfo.java
@@ -47,6 +47,15 @@ public class SessionInfo {
             && getUserEmail() != null
             && !isExpired();
     }
+
+    public boolean shouldRenew() {
+        final Date expirationTime = claimsSet.getExpirationTime();
+        if(expirationTime == null) {
+            return false;
+        }
+        final long remainingTime = expirationTime.getTime() - System.currentTimeMillis();
+        return remainingTime < Duration.ofMinutes(5).toMillis();
+    }
     
     public Payload toPayload() {
         return new Payload(claimsSet.toJSONObject());
@@ -89,6 +98,12 @@ public class SessionInfo {
         public Builder expireAfter(final Duration ttl) {
             final Date expirationTime = new Date(System.currentTimeMillis() + ttl.toMillis());
             claimBuilder.expirationTime(expirationTime);
+            return this;
+        }
+        public Builder from(final SessionInfo sessionInfo) {
+            claimBuilder.subject(sessionInfo.getUserId());
+            claimBuilder.claim("email", sessionInfo.getUserEmail());
+            claimBuilder.expirationTime(sessionInfo.claimsSet.getExpirationTime());
             return this;
         }
 

--- a/remsfal-service/src/main/java/de/remsfal/service/boundary/authentication/SessionManager.java
+++ b/remsfal-service/src/main/java/de/remsfal/service/boundary/authentication/SessionManager.java
@@ -116,6 +116,13 @@ public class SessionManager {
         return decryptSessionObject(sessionCookie.getValue());
     }
 
+    public NewCookie renewSessionCookie(final SessionInfo sessionInfo) {
+        SessionInfo info = SessionInfo.builder().from(sessionInfo)
+                .expireAfter(sessionCookieTimeout)
+                .build();
+        return encryptSessionCookie(info);
+    }
+
     public NewCookie removalSessionCookie() {
         return new NewCookie.Builder(COOKIE_NAME)
             .value("")

--- a/remsfal-service/src/test/java/de/remsfal/service/boundary/authentication/SessionInfoTest.java
+++ b/remsfal-service/src/test/java/de/remsfal/service/boundary/authentication/SessionInfoTest.java
@@ -1,0 +1,124 @@
+package de.remsfal.service.boundary.authentication;
+
+import org.junit.jupiter.api.Test;
+
+import com.nimbusds.jwt.JWTClaimsSet;
+import com.nimbusds.jose.Payload;
+
+import java.text.ParseException;
+import java.time.Duration;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+class SessionInfoTest {
+
+    @Test
+    void sessionInfo_shouldContainUserIdAndEmail() {
+        String userId = "testUser";
+        String userEmail = "test@example.com";
+        SessionInfo sessionInfo = SessionInfo.builder()
+                .userId(userId)
+                .userEmail(userEmail)
+                .expireAfter(Duration.ofMinutes(30))
+                .build();
+
+        assertEquals(userId, sessionInfo.getUserId());
+        assertEquals(userEmail, sessionInfo.getUserEmail());
+        assertFalse(sessionInfo.isExpired());
+        assertTrue(sessionInfo.isValid());
+    }
+
+    @Test
+    void sessionInfo_shouldExpireCorrectly() {
+        SessionInfo sessionInfo = SessionInfo.builder()
+                .userId("testUser")
+                .userEmail("test@example.com")
+                .expireAfter(Duration.ofMillis(500))
+                .build();
+
+        try {
+            Thread.sleep(600);
+        } catch (InterruptedException e) {
+            Thread.currentThread().interrupt();
+        }
+
+        assertTrue(sessionInfo.isExpired());
+        assertFalse(sessionInfo.isValid());
+    }
+
+    @Test
+    void sessionInfo_shouldRenewBeforeExpiration() {
+
+        SessionInfo sessionInfo = SessionInfo.builder()
+                .userId("testUser")
+                .userEmail("test@example.com")
+                .expireAfter(Duration.ofMinutes(4))
+                .build();
+
+        boolean shouldRenew = sessionInfo.shouldRenew();
+
+        assertTrue(shouldRenew);
+    }
+
+    @Test
+    void sessionInfo_shouldNotRenewIfSufficientTimeLeft() {
+
+        SessionInfo sessionInfo = SessionInfo.builder()
+                .userId("testUser")
+                .userEmail("test@example.com")
+                .expireAfter(Duration.ofMinutes(10))
+                .build();
+
+        boolean shouldRenew = sessionInfo.shouldRenew();
+
+        assertFalse(shouldRenew);
+    }
+
+    @Test
+    void sessionInfo_shouldConvertToPayloadAndBack() throws ParseException {
+
+        String userId = "testUser";
+        String userEmail = "test@example.com";
+        SessionInfo sessionInfo = SessionInfo.builder()
+                .userId(userId)
+                .userEmail(userEmail)
+                .expireAfter(Duration.ofMinutes(30))
+                .build();
+
+        Payload payload = sessionInfo.toPayload();
+        SessionInfo reconstructedSessionInfo = new SessionInfo(payload);
+
+        assertEquals(sessionInfo.getUserId(), reconstructedSessionInfo.getUserId());
+        assertEquals(sessionInfo.getUserEmail(), reconstructedSessionInfo.getUserEmail());
+        assertFalse(reconstructedSessionInfo.isExpired());
+    }
+
+    @Test
+    void sessionInfo_builderShouldCopyValuesCorrectly() {
+
+        SessionInfo originalSessionInfo = SessionInfo.builder()
+                .userId("originalUser")
+                .userEmail("original@example.com")
+                .expireAfter(Duration.ofMinutes(30))
+                .build();
+
+        SessionInfo copiedSessionInfo = SessionInfo.builder().from(originalSessionInfo).build();
+
+        assertEquals(originalSessionInfo.getUserId(), copiedSessionInfo.getUserId());
+        assertEquals(originalSessionInfo.getUserEmail(), copiedSessionInfo.getUserEmail());
+        assertFalse(copiedSessionInfo.isExpired());
+    }
+
+    @Test
+    void sessionInfo_shouldHandleNullExpirationTime() {
+
+        JWTClaimsSet claimsSet = new JWTClaimsSet.Builder()
+                .subject("testUser")
+                .claim("email", "test@example.com")
+                .build();
+        SessionInfo sessionInfo = new SessionInfo(claimsSet);
+
+        assertTrue(sessionInfo.isExpired());
+        assertFalse(sessionInfo.isValid());
+    }
+}

--- a/remsfal-service/src/test/java/de/remsfal/service/boundary/authentication/SessionManagerTest.java
+++ b/remsfal-service/src/test/java/de/remsfal/service/boundary/authentication/SessionManagerTest.java
@@ -1,0 +1,127 @@
+package de.remsfal.service.boundary.authentication;
+
+import de.remsfal.service.boundary.exception.UnauthorizedException;
+import io.quarkus.test.junit.QuarkusTest;
+import jakarta.inject.Inject;
+import jakarta.ws.rs.InternalServerErrorException;
+import org.junit.jupiter.api.Test;
+
+import jakarta.ws.rs.core.Cookie;
+import jakarta.ws.rs.core.NewCookie;
+
+import java.time.Duration;
+import java.util.HashMap;
+import java.util.Map;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+@QuarkusTest
+class SessionManagerTest {
+
+    @Inject
+    SessionManager sessionManager;
+
+    @Test
+    void encryptAndDecryptSessionObject_shouldWorkCorrectly() {
+        SessionInfo sessionInfo = SessionInfo.builder()
+                .userId("testUser")
+                .userEmail("test@example.com")
+                .expireAfter(Duration.ofMinutes(30))
+                .build();
+
+        String encrypted = sessionManager.encryptSessionObject(sessionInfo);
+        SessionInfo decrypted = sessionManager.decryptSessionObject(encrypted);
+
+        assertEquals(sessionInfo.getUserId(), decrypted.getUserId());
+        assertEquals(sessionInfo.getUserEmail(), decrypted.getUserEmail());
+        assertFalse(decrypted.isExpired());
+    }
+
+    @Test
+    void encryptSessionCookie_shouldReturnValidCookie() {
+        SessionInfo sessionInfo = SessionInfo.builder()
+                .userId("testUser")
+                .userEmail("test@example.com")
+                .expireAfter(Duration.ofMinutes(30))
+                .build();
+
+        NewCookie cookie = sessionManager.encryptSessionCookie(sessionInfo);
+
+        assertEquals(SessionManager.COOKIE_NAME, cookie.getName());
+        assertNotNull(cookie.getValue());
+        assertEquals("/;SameSite=Strict", cookie.getPath());
+        assertEquals(30 * 60, cookie.getMaxAge());
+    }
+
+    @Test
+    void decryptSessionCookie_shouldReturnValidSessionInfo() {
+        SessionInfo sessionInfo = SessionInfo.builder()
+                .userId("testUser")
+                .userEmail("test@example.com")
+                .expireAfter(Duration.ofMinutes(30))
+                .build();
+        NewCookie cookie = sessionManager.encryptSessionCookie(sessionInfo);
+
+        SessionInfo decryptedSessionInfo = sessionManager.decryptSessionCookie(
+                new Cookie.Builder(cookie.getName()).value(cookie.getValue()).build()
+        );
+
+        assertEquals(sessionInfo.getUserId(), decryptedSessionInfo.getUserId());
+        assertEquals(sessionInfo.getUserEmail(), decryptedSessionInfo.getUserEmail());
+    }
+
+    @Test
+    void renewSessionCookie_shouldExtendExpirationTime() {
+        SessionInfo sessionInfo = SessionInfo.builder()
+                .userId("testUser")
+                .userEmail("test@example.com")
+                .expireAfter(Duration.ofMinutes(1)) // Short expiration time
+                .build();
+        NewCookie cookie = sessionManager.encryptSessionCookie(sessionInfo);
+
+        NewCookie renewedCookie = sessionManager.renewSessionCookie(
+                sessionManager.decryptSessionCookie(new Cookie.Builder(cookie.getName()).value(cookie.getValue()).build())
+        );
+
+        assertNotEquals(cookie.getValue(), renewedCookie.getValue());
+        assertEquals(SessionManager.COOKIE_NAME, renewedCookie.getName());
+    }
+
+    @Test
+    void removalSessionCookie_shouldReturnEmptyCookie() {
+        NewCookie removalCookie = sessionManager.removalSessionCookie();
+
+        assertEquals(SessionManager.COOKIE_NAME, removalCookie.getName());
+        assertEquals("", removalCookie.getValue());
+        assertEquals(0, removalCookie.getMaxAge());
+    }
+
+    @Test
+    void findSessionCookie_shouldReturnCorrectCookie() {
+        Map<String, Cookie> cookies = new HashMap<>();
+        cookies.put(SessionManager.COOKIE_NAME, new Cookie.Builder(SessionManager.COOKIE_NAME).value("testValue").build());
+
+        Cookie foundCookie = sessionManager.findSessionCookie(cookies);
+
+        assertNotNull(foundCookie);
+        assertEquals("testValue", foundCookie.getValue());
+    }
+
+    @Test
+    void decryptSessionCookie_shouldThrowExceptionForInvalidCookieName() {
+        Cookie invalidCookie = new Cookie.Builder("invalidCookie").value("testValue").build();
+
+        assertThrows(InternalServerErrorException.class, () ->
+                sessionManager.decryptSessionCookie(invalidCookie)
+        );
+    }
+
+    @Test
+    void decryptSessionObject_shouldThrowUnauthorizedExceptionForInvalidObject() {
+        String invalidSessionObject = "invalidSessionObject";
+
+        assertThrows(UnauthorizedException.class, () ->
+                sessionManager.decryptSessionObject(invalidSessionObject)
+        );
+    }
+}


### PR DESCRIPTION
Closes #36 

## Changes
If the  Cookies-TTL is <= 5 Minutes, the cookie will be renewed

**Please note:** This is just a quick and dirty solution, which should be refactored in future iterations, since its impossible to revoke stolen cookies. Also if the user is inactive long enough, he still needs to login again, since the cookie can only be renewed, as long as its not expired (security)

## Tests
Added new and already missing tests for SessionInfo and SessionManager