### PR TITLE
Integrate Minio for Enhanced File Storage Management

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -28,6 +28,20 @@ services:
       - remsfal
     ports:
       - '9090:9090'
+
+  minio:
+    image: minio/minio
+    container_name: minio
+    environment:
+      - MINIO_ROOT_USER=minioadmin
+      - MINIO_ROOT_PASSWORD=minioadminpassword
+    command: server /data --console-address ":9001"
+    ports:
+      - "9000:9000"
+      - "9001:9001"
+    volumes:
+      - ./data/minio:/data
+
 networks:
   remsfal:
     driver: bridge

--- a/remsfal-core/pom.xml
+++ b/remsfal-core/pom.xml
@@ -68,6 +68,11 @@
             <artifactId>microprofile-openapi-api</artifactId>
             <version>${version.open-api}</version>
         </dependency>
+        <dependency>
+            <groupId>org.jboss.resteasy</groupId>
+            <artifactId>resteasy-multipart-provider</artifactId>
+            <version>6.2.11.Final</version>
+        </dependency>
 
         <!-- TEST dependencies -->
         <dependency>

--- a/remsfal-core/src/main/java/de/remsfal/core/api/project/ChatEndpoint.java
+++ b/remsfal-core/src/main/java/de/remsfal/core/api/project/ChatEndpoint.java
@@ -164,7 +164,7 @@ public interface ChatEndpoint {
 
     @GET
     @Path("/{sessionId}/messages/{messageId}")
-    @Produces(MediaType.APPLICATION_JSON)
+    @Produces({MediaType.APPLICATION_JSON, MediaType.APPLICATION_OCTET_STREAM})
     @Operation(summary = "Get a chat message in a chat session")
     @APIResponse(responseCode = "200", description = "Chat message retrieved")
     @APIResponse(responseCode = "400", description = "Invalid input")
@@ -174,7 +174,7 @@ public interface ChatEndpoint {
     Response getChatMessage(
         @PathParam("sessionId") @NotNull @UUID String sessionId,
         @Parameter(description = "The chat message ID", required = true) @PathParam("messageId")
-        @NotNull @UUID String messageId);
+        @NotNull @UUID String messageId) throws Exception;
 
     @PUT
     @Path("/{sessionId}/messages/{messageId}")

--- a/remsfal-core/src/main/java/de/remsfal/core/api/project/ChatEndpoint.java
+++ b/remsfal-core/src/main/java/de/remsfal/core/api/project/ChatEndpoint.java
@@ -233,6 +233,7 @@ public interface ChatEndpoint {
     @APIResponse(responseCode = "401", description = "No user authentication provided via session cookie")
     Response uploadFile(
             @PathParam("sessionId") @NotNull @UUID String sessionId,
-            @Parameter(description = "Multipart file input", required = true) MultipartFormDataInput input) throws Exception;
+            @Parameter(description = "Multipart file input", required = true) MultipartFormDataInput input)
+            throws Exception;
 
 }

--- a/remsfal-core/src/main/java/de/remsfal/core/api/project/ChatEndpoint.java
+++ b/remsfal-core/src/main/java/de/remsfal/core/api/project/ChatEndpoint.java
@@ -18,9 +18,10 @@ import jakarta.ws.rs.core.Response;
 import org.eclipse.microprofile.openapi.annotations.Operation;
 import org.eclipse.microprofile.openapi.annotations.parameters.Parameter;
 import org.eclipse.microprofile.openapi.annotations.responses.APIResponse;
+import org.jboss.resteasy.plugins.providers.multipart.MultipartFormDataInput;
 
 /**
- * @author: Parham Rahmani [parham.rahmani@student.htw-berlin.de]
+ * @author Parham Rahmani [parham.rahmani@student.htw-berlin.de]
  */
 public interface ChatEndpoint {
 
@@ -218,4 +219,20 @@ public interface ChatEndpoint {
     @APIResponse(responseCode = "401", description = "No user authentication provided via session cookie")
     Response getChatMessages(
         @PathParam("sessionId") @NotNull @UUID String sessionId);
+
+    @POST
+    @Path("/{sessionId}/messages/upload")
+    @Consumes(MediaType.MULTIPART_FORM_DATA)
+    @Produces(MediaType.APPLICATION_JSON)
+    @Operation(summary = "Send a file in a chat session")
+    @APIResponse(responseCode = "201", description = "File sent")
+    @APIResponse(responseCode = "400", description = "Invalid input")
+    @APIResponse(responseCode = "403", description = "Chat session is closed or archived")
+    @APIResponse(responseCode = "404", description = "Project, task, or chat session not found")
+    @APIResponse(responseCode = "500", description = "Internal server error")
+    @APIResponse(responseCode = "401", description = "No user authentication provided via session cookie")
+    Response uploadFile(
+            @PathParam("sessionId") @NotNull @UUID String sessionId,
+            @Parameter(description = "Multipart file input", required = true) MultipartFormDataInput input) throws Exception;
+
 }

--- a/remsfal-core/src/main/java/de/remsfal/core/json/project/ChatMessageJson.java
+++ b/remsfal-core/src/main/java/de/remsfal/core/json/project/ChatMessageJson.java
@@ -51,7 +51,7 @@ public abstract class ChatMessageJson implements ChatMessageModel {
     @Null
     @Nullable
     @Override
-    public abstract String getImageUrl();
+    public abstract String getUrl();
 
     @Null
     @Nullable
@@ -78,7 +78,7 @@ public abstract class ChatMessageJson implements ChatMessageModel {
                 .senderId(model.getSenderId())
                 .contentType(model.getContentType())
                 .content(model.getContent())
-                .imageUrl(model.getImageUrl())
+                .url(model.getUrl())
                 .timestamp(model.getTimestamp())
                 .build();
     }

--- a/remsfal-core/src/main/java/de/remsfal/core/model/project/ChatMessageModel.java
+++ b/remsfal-core/src/main/java/de/remsfal/core/model/project/ChatMessageModel.java
@@ -22,14 +22,14 @@ public interface ChatMessageModel {
 
     enum ContentType {
         TEXT,
-        IMAGE
+        FILE
     }
 
     ContentType getContentType();
 
     String getContent();
 
-    String getImageUrl();
+    String getUrl();
 
     Date getTimestamp();
 

--- a/remsfal-service/pom.xml
+++ b/remsfal-service/pom.xml
@@ -107,6 +107,13 @@
                 </exclusion>
             </exclusions>
         </dependency>
+        <!-- File Storage dependencies - Minio -->
+        <dependency>
+            <groupId>io.quarkiverse.minio</groupId>
+            <artifactId>quarkus-minio</artifactId>
+            <version>3.7.7</version>
+        </dependency>
+
         <!-- Bugfix dependencies -->
         <dependency>
             <!-- JDK 24 support -->

--- a/remsfal-service/src/main/java/de/remsfal/service/boundary/project/ChatResource.java
+++ b/remsfal-service/src/main/java/de/remsfal/service/boundary/project/ChatResource.java
@@ -3,7 +3,13 @@ package de.remsfal.service.boundary.project;
 
 import java.io.InputStream;
 import java.net.URI;
-import java.util.*;
+import java.util.Map;
+import java.util.NoSuchElementException;
+import java.util.Objects;
+import java.util.List;
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.Set;
 
 import de.remsfal.core.model.project.ChatMessageModel.ContentType;
 import de.remsfal.service.control.FileStorageService;

--- a/remsfal-service/src/main/java/de/remsfal/service/boundary/project/ChatResource.java
+++ b/remsfal-service/src/main/java/de/remsfal/service/boundary/project/ChatResource.java
@@ -429,7 +429,7 @@ public class ChatResource extends ProjectSubResource implements ChatEndpoint {
 
         } catch (Exception e) {
             logger.error("Error during file upload", e);
-            throw e; // Propagate the exception as-is
+            throw e;
         }
     }
 

--- a/remsfal-service/src/main/java/de/remsfal/service/boundary/project/ChatResource.java
+++ b/remsfal-service/src/main/java/de/remsfal/service/boundary/project/ChatResource.java
@@ -1,13 +1,12 @@
 package de.remsfal.service.boundary.project;
 
-import java.net.URI;
-import java.util.ArrayList;
-import java.util.HashMap;
-import java.util.List;
-import java.util.Map;
-import java.util.NoSuchElementException;
-import java.util.Objects;
 
+import java.io.InputStream;
+import java.net.URI;
+import java.util.*;
+
+import de.remsfal.core.model.project.ChatMessageModel.ContentType;
+import de.remsfal.service.control.FileStorageService;
 import org.jboss.logging.Logger;
 
 import com.google.gson.Gson;
@@ -28,7 +27,12 @@ import jakarta.ws.rs.InternalServerErrorException;
 import jakarta.ws.rs.NotFoundException;
 import jakarta.ws.rs.core.MediaType;
 import jakarta.ws.rs.core.Response;
+import org.jboss.resteasy.plugins.providers.multipart.InputPart;
+import org.jboss.resteasy.plugins.providers.multipart.MultipartFormDataInput;
 
+/**
+ * @author Parham Rahmani [parham.rahmani@student.htw-berlin.de]
+ */
 @RequestScoped
 public class ChatResource extends ProjectSubResource implements ChatEndpoint {
 
@@ -43,6 +47,11 @@ public class ChatResource extends ProjectSubResource implements ChatEndpoint {
 
     @Inject
     Logger logger;
+
+    @Inject
+    FileStorageService fileStorageService;
+
+    private final String bucketName = "remsfal-chat-files";
 
     @Override
     public Response createChatSession() {
@@ -293,6 +302,8 @@ public class ChatResource extends ProjectSubResource implements ChatEndpoint {
 
     }
 
+
+
     @Override
     public Response getChatMessage(String sessionId, String messageId) {
         try {
@@ -353,7 +364,82 @@ public class ChatResource extends ProjectSubResource implements ChatEndpoint {
         }
     }
 
-    public String jsonifyParticipantsMap(Map<String, ChatSessionModel.ParticipantRole> participants) {
+
+    @Override
+    public Response uploadFile(String sessionId, MultipartFormDataInput input) throws Exception {
+        try {
+            String userId = principal.getId();
+            String projectId = uri.getPathParameters().getFirst("projectId");
+            checkPrivileges(projectId);
+
+            Map<String, List<InputPart>> formDataMap = input.getFormDataMap();
+            List<InputPart> fileParts = formDataMap.get("file");
+            if (fileParts == null || fileParts.isEmpty()) {
+                logger.error("No 'file' part found in the form data");
+                return Response.status(Response.Status.BAD_REQUEST)
+                        .entity("{\"message\": \"No file part found in the form data\"}")
+                        .type(MediaType.APPLICATION_JSON)
+                        .build();
+            }
+
+            for (InputPart inputPart : fileParts) {
+                String fileName = getFileName(inputPart.getHeaders());
+                if (!isFileNameValid(fileName)) {
+                    logger.error("Invalid file name: " + fileName);
+                    return Response.status(Response.Status.BAD_REQUEST)
+                            .entity("{\"message\": \"Invalid file name: " + fileName + "\"}")
+                            .type(MediaType.APPLICATION_JSON)
+                            .build();
+                }
+
+                String contentType = inputPart.getMediaType().toString();
+                if (!isContentTypeValid(contentType)) {
+                    logger.error("Invalid file type: " + contentType);
+                    return Response.status(Response.Status.UNSUPPORTED_MEDIA_TYPE)
+                            .entity("{\"message\": \"Unsupported Media Type: " + contentType + "\"}")
+                            .type(MediaType.APPLICATION_JSON)
+                            .build();
+                }
+
+                try (InputStream fileStream = inputPart.getBody(InputStream.class, null)) {
+                    if (fileStream == null || fileStream.available() == 0) {
+                        logger.error("File stream is null or empty");
+                        return Response.status(Response.Status.BAD_REQUEST)
+                                .entity("{\"message\": \"Failed to read file stream: unknown\"}")
+                                .type(MediaType.APPLICATION_JSON)
+                                .build();
+                    }
+
+
+                    String fileUrl = fileStorageService.uploadFile(bucketName, input);
+
+                    ChatMessageEntity fileMetadataEntity = chatMessageController
+                            .sendChatMessage(sessionId, userId, ContentType.FILE, fileUrl);
+
+                    String jsonResponse = String.format("{\"fileId\": \"%s\", \"fileUrl\": \"%s\"}",
+                            fileMetadataEntity.getId(), fileUrl);
+
+                    return Response.status(Response.Status.CREATED)
+                            .entity(jsonResponse)
+                            .build();
+                }
+            }
+
+            throw new BadRequestException("No valid file uploaded");
+
+        } catch (Exception e) {
+            logger.error("Error during file upload", e);
+            throw e; // Propagate the exception as-is
+        }
+    }
+
+
+
+
+
+    //---------------------Helper Methods---------------------
+
+    private String jsonifyParticipantsMap(Map<String, ChatSessionModel.ParticipantRole> participants) {
         List<Map<String, String>> participantList = new ArrayList<>();
         participants.forEach((id, role) -> {
             Map<String, String> participant = new HashMap<>();
@@ -364,4 +450,37 @@ public class ChatResource extends ProjectSubResource implements ChatEndpoint {
         Gson gson = new Gson();
         return gson.toJson(participantList);
     }
+
+    private String getFileName(Map<String, List<String>> headers) {
+        List<String> contentDisposition = headers.get("Content-Disposition");
+        if (contentDisposition != null && !contentDisposition.isEmpty()) {
+            for (String part : contentDisposition.get(0).split(";")) {
+                if (part.trim().startsWith("filename")) {
+                    return part.split("=")[1].trim().replaceAll("\"", "");
+                }
+            }
+        }
+        return "unknown";
+    }
+
+    private boolean isFileNameValid(String fileName) {
+        if (fileName == null || fileName.isBlank()) {
+            return false;
+        }
+        return fileName.matches("^[\\w\\-. ]+$");
+    }
+
+    private boolean isContentTypeValid(String contentType) {
+        if (contentType == null) {
+            return false;
+        }
+        // Normalize content type (remove charset if present)
+        String normalizedContentType = contentType.split(";")[0].trim();
+        Set <String> allowedTypes = fileStorageService.getAllowedTypes();
+        return allowedTypes.contains(normalizedContentType);
+    }
+
+
+
+
 }

--- a/remsfal-service/src/main/java/de/remsfal/service/control/ChatMessageController.java
+++ b/remsfal-service/src/main/java/de/remsfal/service/control/ChatMessageController.java
@@ -29,8 +29,6 @@ public class ChatMessageController {
         repository.updateTextChatMessage(messageId, content);
     }
 
-    // TODO: Implement image chat message update
-
     public void deleteChatMessage(String messageId) {
         logger.infov("Deleting chat message (messageId={0})", messageId);
         repository.deleteChatMessage(messageId);

--- a/remsfal-service/src/main/java/de/remsfal/service/control/FileStorageService.java
+++ b/remsfal-service/src/main/java/de/remsfal/service/control/FileStorageService.java
@@ -1,6 +1,15 @@
 package de.remsfal.service.control;
 
-import io.minio.*;
+import io.minio.MinioClient;
+import io.minio.PutObjectArgs;
+import io.minio.GetObjectArgs;
+import io.minio.StatObjectArgs;
+import io.minio.StatObjectResponse;
+import io.minio.Result;
+import io.minio.ListObjectsArgs;
+import io.minio.RemoveObjectArgs;
+import io.minio.BucketExistsArgs;
+import io.minio.MakeBucketArgs;
 import io.minio.messages.Item;
 import jakarta.enterprise.context.ApplicationScoped;
 import jakarta.inject.Inject;

--- a/remsfal-service/src/main/java/de/remsfal/service/control/FileStorageService.java
+++ b/remsfal-service/src/main/java/de/remsfal/service/control/FileStorageService.java
@@ -1,0 +1,290 @@
+package de.remsfal.service.control;
+
+import io.minio.*;
+import io.minio.messages.Item;
+import jakarta.enterprise.context.ApplicationScoped;
+import jakarta.inject.Inject;
+import org.jboss.resteasy.plugins.providers.multipart.InputPart;
+import org.jboss.resteasy.plugins.providers.multipart.MultipartFormDataInput;
+import io.minio.errors.MinioException;
+import java.io.InputStream;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+
+import org.jboss.logging.Logger;
+
+import org.eclipse.microprofile.config.inject.ConfigProperty;
+
+@ApplicationScoped
+public class FileStorageService {
+
+    private static final String FILE_FORM_FIELD = "file";
+    private static final String CONTENT_DISPOSITION_HEADER = "Content-Disposition";
+    private static final String DEFAULT_FILE_NAME = "unknown";
+
+    private final Set<String> allowedTypes = Set.of(
+            "image/jpeg",
+            "image/png",
+            "image/gif",
+            "text/plain",
+            "application/pdf",
+            "application/msword",
+            "application/vnd.openxmlformats-officedocument.wordprocessingml.document",
+            "application/json"
+    );
+
+    @ConfigProperty(name = "%dev.quarkus.minio.url")
+    String endpoint;
+
+    @Inject
+    Logger logger;
+
+    @Inject
+    MinioClient minioClient;
+
+    public String uploadFile(String bucketName, MultipartFormDataInput input) throws Exception {
+        List<InputPart> inputParts = getFileInputParts(input);
+
+        if (inputParts == null || inputParts.isEmpty()) {
+            logger.error("File is null or empty");
+            throw new MinioException("File is null or empty");
+        }
+
+        InputPart inputPart = inputParts.get(0);
+        String originalFileName = extractFileName(inputPart.getHeaders());
+        String contentType = inputPart.getMediaType().toString();
+
+        if (!isValidContentType(contentType)) {
+            logger.error("Invalid file type: " + contentType);
+            throw new MinioException("Invalid file type: " + contentType);
+        }
+
+        try (InputStream inputStream = inputPart.getBody(InputStream.class, null)) {
+            ensureBucketExists(bucketName);
+            String finalFileName = generateUniqueFileName(bucketName, originalFileName);
+
+            logger.infov("Uploading file {0} to bucket {1} as {2}", originalFileName, bucketName, finalFileName);
+            minioClient.putObject(
+                    PutObjectArgs.builder()
+                            .bucket(bucketName)
+                            .object(finalFileName)
+                            .stream(inputStream, -1, 10485760)
+                            .contentType(contentType)
+                            .build()
+            );
+
+            String fileUrl = constructFileUrl(bucketName, finalFileName);
+            logger.infov("File uploaded successfully. URL: {0}", fileUrl);
+            return fileUrl;
+
+        } catch (MinioException e) {
+            logger.error("Error uploading file to Minio", e);
+            throw e;
+        } catch (Exception e) {
+            logger.error("Failed to process uploaded file", e);
+            throw e;
+        }
+    }
+
+    public InputStream downloadFile(String bucketName, String objectName) throws Exception {
+        logger.infov("Downloading file {0} from bucket {1}", objectName, bucketName);
+
+        if (!checkBucketExists(bucketName)) {
+            throw new MinioException("Bucket does not exist");
+        }
+
+        if (!objectExists(bucketName, objectName)) {
+            logger.errorv("File {0} does not exist in bucket {1}", objectName, bucketName);
+            throw new MinioException("File does not exist");
+        }
+
+        try {
+            GetObjectArgs args = GetObjectArgs.builder()
+                    .bucket(bucketName)
+                    .object(objectName)
+                    .build();
+
+            InputStream stream = minioClient.getObject(args);
+            logger.infov("File {0} from bucket {1} downloaded successfully!", objectName, bucketName);
+            return stream;
+
+        } catch (MinioException e) {
+            logger.error("Error downloading file from Minio", e);
+            throw e;
+        }
+    }
+
+    public String getContentType(String bucketName, String objectName) throws Exception {
+        logger.infov("Retrieving metadata for file {0} in bucket {1}", objectName, bucketName);
+
+        if (!objectExists(bucketName, objectName)) {
+            throw new MinioException("File does not exist");
+        }
+
+        if (!checkBucketExists(bucketName)) {
+            throw new MinioException("Bucket does not exist");
+        }
+
+        try {
+            StatObjectArgs args = StatObjectArgs.builder()
+                    .bucket(bucketName)
+                    .object(objectName)
+                    .build();
+
+            StatObjectResponse stat = minioClient.statObject(args);
+            return stat.contentType();
+
+        } catch (MinioException e) {
+            throw new Exception("Error occurred while retrieving file metadata", e);
+        }
+    }
+
+    public Iterable<Result<Item>> listObjects(String bucketName) throws Exception {
+        if (!checkBucketExists(bucketName)) {
+            throw new MinioException("Bucket does not exist");
+        }
+
+        try {
+            logger.infov("Listing objects in bucket {0}", bucketName);
+            return minioClient.listObjects(ListObjectsArgs.builder()
+                    .bucket(bucketName).build());
+        } catch (Exception e) {
+            logger.error("Error listing objects in bucket", e);
+            throw e;
+        }
+    }
+
+    public void deleteObject(String bucketName, String objectName) throws Exception {
+        if (!objectExists(bucketName, objectName)) {
+            logger.infov("Object {0} does not exist in bucket {1}", objectName, bucketName);
+            throw new MinioException("File does not exist");
+        }
+
+        if (!checkBucketExists(bucketName)) {
+            throw new MinioException("Bucket does not exist");
+        }
+
+        logger.infov("Deleting object {0} from bucket {1}", objectName, bucketName);
+        try {
+            minioClient.removeObject(RemoveObjectArgs.builder().bucket(bucketName).object(objectName).build());
+        } catch (RuntimeException e) {
+            if (e.getMessage().contains("Not found")) {
+                throw new MinioException("File does not exist");
+            }
+            throw e;
+        }
+    }
+
+    private boolean checkBucketExists(String bucketName) throws Exception {
+        logger.infov("Checking if bucket {0} exists", bucketName);
+        boolean exists = minioClient.bucketExists(BucketExistsArgs.builder().bucket(bucketName).build());
+        logger.infov("Bucket {0} exists: {1}", bucketName, exists);
+        return exists;
+    }
+
+    private void ensureBucketExists(String bucketName) throws Exception {
+        logger.infov("Ensuring bucket {0} exists", bucketName);
+        if (!checkBucketExists(bucketName)) {
+            logger.infov("No bucket named {0} was found! Creating one", bucketName);
+            createBucket(bucketName);
+        }
+    }
+
+    private void createBucket(String bucketName) throws Exception {
+        logger.infov("Creating bucket {0}", bucketName);
+        minioClient.makeBucket(MakeBucketArgs.builder().bucket(bucketName).build());
+    }
+
+    private boolean objectExists(String bucketName, String objectName) throws MinioException {
+        logger.infov("Checking if object {0} exists in bucket {1}", objectName, bucketName);
+        try {
+            minioClient.statObject(StatObjectArgs.builder().bucket(bucketName).object(objectName).build());
+            logger.infov("Object {0} exists in bucket {1}", objectName, bucketName);
+            return true;
+        } catch (io.minio.errors.ErrorResponseException e) {
+            if (e.response().code() == 404) {
+                logger.infov("Object {0} does not exist in bucket {1}", objectName, bucketName);
+                return false;
+            }
+            logger.error("Error checking if object exists", e);
+            throw new MinioException("Error checking if object exists: " + e.getMessage());
+        } catch (Exception e) {
+            logger.error("Unexpected error while checking if object exists", e);
+            throw new MinioException("Unexpected error while checking if object exists: " + e.getMessage());
+        }
+    }
+
+    private String extractFileName(Map<String, List<String>> headers) {
+        logger.infov("Retrieving file name from headers: {0}", headers);
+        List<String> contentDispositionList = headers.get(CONTENT_DISPOSITION_HEADER);
+
+        if (contentDispositionList == null || contentDispositionList.isEmpty()) {
+            logger.warn("Content-Disposition header is missing");
+            return DEFAULT_FILE_NAME;
+        }
+
+        String contentDisposition = contentDispositionList.get(0);
+        for (String part : contentDisposition.split(";")) {
+            part = part.trim();
+            if (part.startsWith("filename")) {
+                String[] nameParts = part.split("=");
+                if (nameParts.length > 1) {
+                    String fileName = nameParts[1].trim().replaceAll("\"", "");
+                    logger.infov("Extracted file name: {0}", fileName);
+                    return fileName;
+                }
+            }
+        }
+
+        logger.warn("Filename not found in Content-Disposition header, using default name 'unknown'");
+        return DEFAULT_FILE_NAME;
+    }
+
+    private boolean isValidContentType(String contentType) {
+        logger.infov("Checking if content type {0} is valid", contentType);
+        boolean isValid = allowedTypes.contains(contentType);
+        if (!isValid) {
+            logger.warnv("Content type {0} is not allowed", contentType);
+        }
+        return isValid;
+    }
+
+    private List<InputPart> getFileInputParts(MultipartFormDataInput input) {
+        logger.infov("Retrieving file input parts: {0}", input);
+        Map<String, List<InputPart>> uploadForm = input.getFormDataMap();
+        List<InputPart> fileParts = uploadForm.get(FILE_FORM_FIELD);
+        if (fileParts == null || fileParts.isEmpty()) {
+            logger.warn("No 'file' part found in the form data");
+        }
+        return fileParts;
+    }
+
+    private String constructFileUrl(String bucketName, String fileName) {
+        String fileUrl = endpoint.endsWith("/") ? endpoint : endpoint + "/";
+        fileUrl += bucketName + "/" + fileName;
+        logger.infov("Constructed file URL: {0}", fileUrl);
+        return fileUrl;
+    }
+
+    private String generateUniqueFileName(String bucketName, String fileName) throws Exception {
+        logger.infov("Generating unique file name for '{0}' in bucket '{1}'", fileName, bucketName);
+
+        if (!objectExists(bucketName, fileName)) {
+            return fileName;
+        }
+
+        int dotIndex = fileName.lastIndexOf('.');
+        String baseName = (dotIndex == -1) ? fileName : fileName.substring(0, dotIndex);
+        String extension = (dotIndex == -1) ? "" : fileName.substring(dotIndex);
+        int counter = 1;
+        String candidate;
+
+        do {
+            candidate = String.format("%s(%d)%s", baseName, counter++, extension);
+        } while (objectExists(bucketName, candidate));
+
+        logger.infov("Generated unique file name: {0}", candidate);
+        return candidate;
+    }
+}

--- a/remsfal-service/src/main/java/de/remsfal/service/control/FileStorageService.java
+++ b/remsfal-service/src/main/java/de/remsfal/service/control/FileStorageService.java
@@ -24,7 +24,9 @@ import java.util.Set;
 import org.jboss.logging.Logger;
 
 import org.eclipse.microprofile.config.inject.ConfigProperty;
-
+/**
+ * @author Parham Rahmani [parham.rahmani@student.htw-berlin.de]
+ */
 @ApplicationScoped
 public class FileStorageService {
 
@@ -252,12 +254,20 @@ public class FileStorageService {
 
     private boolean isValidContentType(String contentType) {
         logger.infov("Checking if content type {0} is valid", contentType);
-        boolean isValid = allowedTypes.contains(contentType);
+
+        // Normalize the content type to remove parameters (e.g., charset=UTF-8)
+        String normalizedContentType = contentType.split(";")[0].trim();
+
+        // Check against the allowed types
+        boolean isValid = allowedTypes.contains(normalizedContentType);
+
         if (!isValid) {
             logger.warnv("Content type {0} is not allowed", contentType);
         }
+
         return isValid;
     }
+
 
     private List<InputPart> getFileInputParts(MultipartFormDataInput input) {
         logger.infov("Retrieving file input parts: {0}", input);
@@ -295,5 +305,9 @@ public class FileStorageService {
 
         logger.infov("Generated unique file name: {0}", candidate);
         return candidate;
+    }
+
+    public Set<String> getAllowedTypes() {
+        return allowedTypes;
     }
 }

--- a/remsfal-service/src/main/java/de/remsfal/service/entity/dao/ChatMessageRepository.java
+++ b/remsfal-service/src/main/java/de/remsfal/service/entity/dao/ChatMessageRepository.java
@@ -55,8 +55,8 @@ public class ChatMessageRepository extends AbstractRepository<ChatMessageEntity>
 
             if (contentType == ContentType.TEXT) {
                 chatMessage.setContent(content);
-            } else if (contentType == ContentType.IMAGE) {
-                chatMessage.setImageUrl(content);
+            } else if (contentType == ContentType.FILE) {
+                chatMessage.setUrl(content);
             } else {
                 throw new IllegalArgumentException("Invalid content type");
             }
@@ -118,19 +118,19 @@ public class ChatMessageRepository extends AbstractRepository<ChatMessageEntity>
         ChatSessionEntity session = message.getChatSession();
         String sessionId = session.getId();
 
-        if (message.getContentType() != ContentType.IMAGE) {
+        if (message.getContentType() != ContentType.FILE) {
             throw new IllegalArgumentException("Cannot update non-image message with updateImageURL() method");
         }
         if (newImageUrl == null || newImageUrl.isBlank()) {
             throw new IllegalArgumentException("Image URL cannot be null or empty");
         }
-        if (newImageUrl.equals(message.getImageUrl())) {
+        if (newImageUrl.equals(message.getUrl())) {
             throw new IllegalArgumentException("Image URL is the same as the current image URL");
         }
         if (session.getStatus() == ChatSessionModel.Status.CLOSED || session.getStatus() ==
                 ChatSessionModel.Status.ARCHIVED) {
             throw new IllegalStateException("ChatSession with ID " + sessionId + " is closed or archived");
         }
-        message.setImageUrl(newImageUrl);
+        message.setUrl(newImageUrl);
     }
 }

--- a/remsfal-service/src/main/java/de/remsfal/service/entity/dao/ChatSessionRepository.java
+++ b/remsfal-service/src/main/java/de/remsfal/service/entity/dao/ChatSessionRepository.java
@@ -97,8 +97,8 @@ public class ChatSessionRepository extends AbstractRepository<ChatSessionEntity>
             message.getSenderId()).name());
         messageJsonMap.put("MESSAGE_TYPE", message.getContentType());
 
-        if (message.getContentType() == ContentType.IMAGE) {
-            messageJsonMap.put("MESSAGE_CONTENT", message.getImageUrl());
+        if (message.getContentType() == ContentType.FILE) {
+            messageJsonMap.put("MESSAGE_CONTENT", message.getUrl());
         } else {
             messageJsonMap.put("MESSAGE_CONTENT", message.getContent());
         }

--- a/remsfal-service/src/main/java/de/remsfal/service/entity/dto/ChatMessageEntity.java
+++ b/remsfal-service/src/main/java/de/remsfal/service/entity/dto/ChatMessageEntity.java
@@ -44,8 +44,8 @@ public class ChatMessageEntity extends AbstractEntity implements ChatMessageMode
     @Column(name = "CONTENT")
     private String content;
 
-    @Column(name = "IMAGE_URL")
-    private String imageUrl;
+    @Column(name = "URL")
+    private String url;
 
     @Override
     public Date getTimestamp() {
@@ -115,18 +115,18 @@ public class ChatMessageEntity extends AbstractEntity implements ChatMessageMode
     }
 
     @Override
-    public String getImageUrl() {
-        return imageUrl;
+    public String getUrl() {
+        return url;
     }
 
-    public void setImageUrl(final String imageUrl) {
-        this.imageUrl = imageUrl;
+    public void setUrl(final String imageUrl) {
+        this.url = imageUrl;
     }
 
 
     @Override
     public int hashCode() {
-        return Objects.hash(id, sender.getId(), contentType, content, imageUrl, getCreatedAt());
+        return Objects.hash(id, sender.getId(), contentType, content, url, getCreatedAt());
     }
 
     @Override
@@ -138,7 +138,7 @@ public class ChatMessageEntity extends AbstractEntity implements ChatMessageMode
                 Objects.equals(getSenderId(), that.getSenderId()) &&
                 contentType == that.contentType &&
                 Objects.equals(content, that.content) &&
-                Objects.equals(imageUrl, that.imageUrl) &&
+                Objects.equals(url, that.url) &&
                 Objects.equals(getCreatedAt(), that.getCreatedAt());
     }
 }

--- a/remsfal-service/src/main/resources/META-INF/liquibase-changelog-0_1_2.xml
+++ b/remsfal-service/src/main/resources/META-INF/liquibase-changelog-0_1_2.xml
@@ -1,0 +1,23 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<databaseChangeLog xmlns="http://www.liquibase.org/xml/ns/dbchangelog"
+                   xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+                   xsi:schemaLocation="http://www.liquibase.org/xml/ns/dbchangelog
+                                       http://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-latest.xsd">
+
+    <!-- ChangeSet to update ENUM and rename column -->
+    <changeSet id="remsfal-backend-0.1.2-rename-enum-and-column" author="parhamrahmani13762@gmail.com">
+
+        <!-- Modify the CONTENT_TYPE ENUM: Rename IMAGE to FILE -->
+        <sql>
+            ALTER TABLE CHAT_MESSAGE
+                MODIFY CONTENT_TYPE ENUM('TEXT', 'FILE') NOT NULL;
+        </sql>
+
+        <!-- Rename the IMAGE_URL column to URL -->
+        <renameColumn tableName="CHAT_MESSAGE"
+                      oldColumnName="IMAGE_URL"
+                      newColumnName="URL"
+                      columnDataType="varchar(255)"/>
+    </changeSet>
+
+</databaseChangeLog>

--- a/remsfal-service/src/main/resources/META-INF/liquibase-changelog.xml
+++ b/remsfal-service/src/main/resources/META-INF/liquibase-changelog.xml
@@ -15,5 +15,6 @@
     <include file="META-INF/liquibase-changelog-0_0_5.xml"/>
     <include file="META-INF/liquibase-changelog-0_1_0.xml"/>
     <include file="META-INF/liquibase-changelog-0_1_1.xml" />
+    <include file="META-INF/liquibase-changelog-0_1_2.xml" />
 
 </databaseChangeLog>

--- a/remsfal-service/src/main/resources/application.properties
+++ b/remsfal-service/src/main/resources/application.properties
@@ -41,11 +41,17 @@ de.remsfal.auth.oidc.client-id=821093255871-8pnrdogfojdc36mqooovf951ao9r4o8i.app
 de.remsfal.auth.oidc.client-secret=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
 de.remsfal.auth.session.secret=removeMe
 
-# MinIO configuration
-%test.quarkus.minio.devservices.enabled=true
+# MinIO configuration for Test Profile
+%test.quarkus.minio.devservices.enabled=false
+%test.quarkus.minio.url=http://localhost:9000
+%test.quarkus.minio.access-key=minioadmin
+%test.quarkus.minio.secret-key=minioadminpassword
+%test.quarkus.minio.secure=false
+# MinIO configuration for Dev Profile
 %dev.quarkus.minio.devservices.enabled=true
 %dev.quarkus.minio.url=http://localhost:9000
 %dev.quarkus.minio.access-key=minioadmin
 %dev.quarkus.minio.secret-key=minioadminpassword
-minio.secure=false
+%dev.quarkus.minio.secure=false
+
 

--- a/remsfal-service/src/main/resources/application.properties
+++ b/remsfal-service/src/main/resources/application.properties
@@ -42,6 +42,7 @@ de.remsfal.auth.oidc.client-secret=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
 de.remsfal.auth.session.secret=removeMe
 
 # MinIO configuration
+%test.quarkus.minio.devservices.enabled=true
 %dev.quarkus.minio.devservices.enabled=true
 %dev.quarkus.minio.url=http://localhost:9000
 %dev.quarkus.minio.access-key=minioadmin

--- a/remsfal-service/src/main/resources/application.properties
+++ b/remsfal-service/src/main/resources/application.properties
@@ -40,3 +40,11 @@ quarkus.liquibase.change-log=META-INF/liquibase-changelog.xml
 de.remsfal.auth.oidc.client-id=821093255871-8pnrdogfojdc36mqooovf951ao9r4o8i.apps.googleusercontent.com
 de.remsfal.auth.oidc.client-secret=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
 de.remsfal.auth.session.secret=removeMe
+
+# MinIO configuration
+%test.quarkus.minio.devservices.enabled=true
+%dev.quarkus.minio.devservices.enabled=false
+%dev.quarkus.minio.url=http://localhost:9000
+%dev.quarkus.minio.access-key=minioadmin
+%dev.quarkus.minio.secret-key=minioadminpassword
+minio.secure=false

--- a/remsfal-service/src/main/resources/application.properties
+++ b/remsfal-service/src/main/resources/application.properties
@@ -42,9 +42,9 @@ de.remsfal.auth.oidc.client-secret=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
 de.remsfal.auth.session.secret=removeMe
 
 # MinIO configuration
-%test.quarkus.minio.devservices.enabled=true
-%dev.quarkus.minio.devservices.enabled=false
+%dev.quarkus.minio.devservices.enabled=true
 %dev.quarkus.minio.url=http://localhost:9000
 %dev.quarkus.minio.access-key=minioadmin
 %dev.quarkus.minio.secret-key=minioadminpassword
 minio.secure=false
+

--- a/remsfal-service/src/main/resources/application.properties
+++ b/remsfal-service/src/main/resources/application.properties
@@ -42,13 +42,13 @@ de.remsfal.auth.oidc.client-secret=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
 de.remsfal.auth.session.secret=removeMe
 
 # MinIO configuration for Test Profile
-%test.quarkus.minio.devservices.enabled=false
+%test.quarkus.minio.devservices.enabled=true
 %test.quarkus.minio.url=http://localhost:9000
 %test.quarkus.minio.access-key=minioadmin
 %test.quarkus.minio.secret-key=minioadminpassword
 %test.quarkus.minio.secure=false
 # MinIO configuration for Dev Profile
-%dev.quarkus.minio.devservices.enabled=true
+%dev.quarkus.minio.devservices.enabled=false
 %dev.quarkus.minio.url=http://localhost:9000
 %dev.quarkus.minio.access-key=minioadmin
 %dev.quarkus.minio.secret-key=minioadminpassword

--- a/remsfal-service/src/main/resources/application.properties
+++ b/remsfal-service/src/main/resources/application.properties
@@ -41,17 +41,9 @@ de.remsfal.auth.oidc.client-id=821093255871-8pnrdogfojdc36mqooovf951ao9r4o8i.app
 de.remsfal.auth.oidc.client-secret=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
 de.remsfal.auth.session.secret=removeMe
 
-# MinIO configuration for Test Profile
-%test.quarkus.minio.devservices.enabled=true
-%test.quarkus.minio.url=http://localhost:9000
-%test.quarkus.minio.access-key=minioadmin
-%test.quarkus.minio.secret-key=minioadminpassword
-%test.quarkus.minio.secure=false
 # MinIO configuration for Dev Profile
 %dev.quarkus.minio.devservices.enabled=false
 %dev.quarkus.minio.url=http://localhost:9000
 %dev.quarkus.minio.access-key=minioadmin
 %dev.quarkus.minio.secret-key=minioadminpassword
 %dev.quarkus.minio.secure=false
-
-

--- a/remsfal-service/src/test/java/de/remsfal/service/control/FileStorageServiceTest.java
+++ b/remsfal-service/src/test/java/de/remsfal/service/control/FileStorageServiceTest.java
@@ -74,28 +74,26 @@ public class FileStorageServiceTest {
     }
 
     @Test
-    public void testUploadFile_NoFilePart_Failure() throws Exception {
+    public void testUploadFile_NoFilePart_Failure() {
         // Simulate a MultipartFormDataInput with no "file" entry
         MultipartFormDataInput input = mock(MultipartFormDataInput.class);
         when(input.getFormDataMap()).thenReturn(Map.of());
 
         fileStorageService.logger = Logger.getLogger(FileStorageService.class);
-        MinioException thrown = Assertions.assertThrows(MinioException.class, () -> {
-            fileStorageService.uploadFile(BUCKET_NAME, input);
-        });
+        MinioException thrown = Assertions.assertThrows(MinioException.class, ()
+                -> fileStorageService.uploadFile(BUCKET_NAME, input));
         assertTrue(thrown.getMessage().contains("File is null or empty"));
     }
 
     @Test
-    public void testUploadFile_EmptyFilePart_Failure() throws Exception {
+    public void testUploadFile_EmptyFilePart_Failure() {
         // Simulate a MultipartFormDataInput with empty file list
         MultipartFormDataInput input = mock(MultipartFormDataInput.class);
         when(input.getFormDataMap()).thenReturn(Map.of("file", List.of()));
 
         fileStorageService.logger = Logger.getLogger(FileStorageService.class);
-        MinioException thrown = Assertions.assertThrows(MinioException.class, () -> {
-            fileStorageService.uploadFile(BUCKET_NAME, input);
-        });
+        MinioException thrown = Assertions.assertThrows(MinioException.class, ()
+                -> fileStorageService.uploadFile(BUCKET_NAME, input));
 
         assertTrue(thrown.getMessage().contains("File is null or empty"));
     }
@@ -108,9 +106,8 @@ public class FileStorageServiceTest {
 
         MultipartFormDataInput input = createMultipartFormDataInput(fileName, contentType, fileContent);
         fileStorageService.logger = Logger.getLogger(FileStorageService.class);
-        MinioException thrown = Assertions.assertThrows(MinioException.class, () -> {
-            fileStorageService.uploadFile(BUCKET_NAME, input);
-        });
+        MinioException thrown = Assertions.assertThrows(MinioException.class, () ->
+                fileStorageService.uploadFile(BUCKET_NAME, input));
         assertTrue(thrown.getMessage().contains("Invalid file type"));
     }
 
@@ -131,9 +128,8 @@ public class FileStorageServiceTest {
         testService.minioClient = mockClient;
         testService.endpoint = "http://localhost:9000";
         testService.logger = Logger.getLogger(FileStorageService.class);
-        Exception thrown = Assertions.assertThrows(Exception.class, () -> {
-            testService.uploadFile("new-bucket", input);
-        });
+        Exception thrown = Assertions.assertThrows(Exception.class, () ->
+                testService.uploadFile("new-bucket", input));
         assertTrue(thrown.getMessage().contains("Bucket creation failed"));
     }
 
@@ -165,10 +161,9 @@ public class FileStorageServiceTest {
     }
 
     @Test
-    public void testDownloadFile_NotFound_Failure() throws Exception {
-        Exception thrown = Assertions.assertThrows(Exception.class, () -> {
-            fileStorageService.downloadFile(BUCKET_NAME, "non-existent-file.txt");
-        });
+    public void testDownloadFile_NotFound_Failure() {
+        Exception thrown = Assertions.assertThrows(Exception.class, () ->
+                fileStorageService.downloadFile(BUCKET_NAME, "non-existent-file.txt"));
         assertTrue(thrown.getMessage().contains("File does not exist"));
     }
 
@@ -185,9 +180,8 @@ public class FileStorageServiceTest {
 
     @Test
     public void testGetContentType_NotFound_Failure() {
-        Exception thrown = Assertions.assertThrows(Exception.class, () -> {
-            fileStorageService.getContentType(BUCKET_NAME, "ghost-file.txt");
-        });
+        Exception thrown = Assertions.assertThrows(Exception.class, () ->
+                fileStorageService.getContentType(BUCKET_NAME, "ghost-file.txt"));
         assertTrue(thrown.getMessage().contains("File does not exist"));
     }
 
@@ -196,8 +190,10 @@ public class FileStorageServiceTest {
     @Test
     public void testListObjects_Success() throws Exception {
         byte[] content = "some content".getBytes();
-        fileStorageService.uploadFile(BUCKET_NAME, createMultipartFormDataInput("file1.png", "image/png", content));
-        fileStorageService.uploadFile(BUCKET_NAME, createMultipartFormDataInput("file2.png", "image/png", content));
+        fileStorageService.uploadFile(BUCKET_NAME,
+                createMultipartFormDataInput("file1.png", "image/png", content));
+        fileStorageService.uploadFile(BUCKET_NAME,
+                createMultipartFormDataInput("file2.png", "image/png", content));
 
         Iterable<Result<Item>> objects = fileStorageService.listObjects(BUCKET_NAME);
         int count = 0;
@@ -209,10 +205,9 @@ public class FileStorageServiceTest {
     }
 
     @Test
-    public void testListObjects_bucketNotFound_FAILURE() throws Exception {
-        MinioException thrown = Assertions.assertThrows(MinioException.class, () -> {
-            fileStorageService.listObjects("non-existent-bucket");
-        });
+    public void testListObjects_bucketNotFound_FAILURE() {
+        MinioException thrown = Assertions.assertThrows(MinioException.class, () ->
+                fileStorageService.listObjects("non-existent-bucket"));
         assertTrue(thrown.getMessage().contains("Bucket does not exist"));
     }
 
@@ -237,12 +232,10 @@ public class FileStorageServiceTest {
     }
 
     @Test
-    public void testDeleteObject_NotFound_FAILURE() throws Exception
-    {
+    public void testDeleteObject_NotFound_FAILURE() {
         String fileName = "non-existent-file.txt";
-        Exception thrown = Assertions.assertThrows(Exception.class, () -> {
-            fileStorageService.deleteObject(BUCKET_NAME, fileName);
-        });
+        Exception thrown = Assertions.assertThrows(Exception.class, () ->
+                fileStorageService.deleteObject(BUCKET_NAME, fileName));
         assertTrue(thrown.getMessage().contains("File does not exist"));
     }
 

--- a/remsfal-service/src/test/java/de/remsfal/service/control/FileStorageServiceTest.java
+++ b/remsfal-service/src/test/java/de/remsfal/service/control/FileStorageServiceTest.java
@@ -21,6 +21,9 @@ import jakarta.ws.rs.core.MultivaluedMap;
 import java.util.Map;
 import org.jboss.logging.Logger;
 
+/**
+ * @author Parham Rahmani [parham.rahmani@student.htw-berlin.de]
+ */
 @QuarkusTest
 public class FileStorageServiceTest {
 

--- a/remsfal-service/src/test/java/de/remsfal/service/control/FileStorageServiceTest.java
+++ b/remsfal-service/src/test/java/de/remsfal/service/control/FileStorageServiceTest.java
@@ -23,6 +23,7 @@ import java.util.Map;
 import org.jboss.logging.Logger;
 
 @QuarkusTest
+@TestInstance(TestInstance.Lifecycle.PER_CLASS)
 public class FileStorageServiceTest {
 
     @Inject
@@ -30,17 +31,19 @@ public class FileStorageServiceTest {
 
     private static final String BUCKET_NAME = "test-bucket";
 
+    @Inject
+    MinioClient minioClient;
+
     @BeforeAll
-    public static void setup() throws Exception {
-        try (MinioClient client = MinioClient.builder()
-                .endpoint("http://localhost:9000")
-                .credentials("minioadmin", "minioadminpassword")
-                .build()) {
-            boolean bucketExists = client.bucketExists(BucketExistsArgs.builder().bucket(BUCKET_NAME).build());
+    public void setup() throws Exception {
+        try {
+            boolean bucketExists = minioClient.bucketExists(BucketExistsArgs.builder().bucket(BUCKET_NAME).build());
 
             if (!bucketExists) {
-                client.makeBucket(MakeBucketArgs.builder().bucket(BUCKET_NAME).build());
+                minioClient.makeBucket(MakeBucketArgs.builder().bucket(BUCKET_NAME).build());
             }
+        } catch (Exception e) {
+            fail("Failed to initialize MinIO bucket: " + e.getMessage());
         }
     }
 

--- a/remsfal-service/src/test/java/de/remsfal/service/control/FileStorageServiceTest.java
+++ b/remsfal-service/src/test/java/de/remsfal/service/control/FileStorageServiceTest.java
@@ -1,0 +1,268 @@
+package de.remsfal.service.control;
+
+import io.minio.*;
+import io.minio.errors.MinioException;
+import io.minio.messages.Item;
+import io.quarkus.test.junit.QuarkusTest;
+import jakarta.inject.Inject;
+import jakarta.ws.rs.core.MediaType;
+import org.jboss.resteasy.plugins.providers.multipart.InputPart;
+import org.jboss.resteasy.plugins.providers.multipart.MultipartFormDataInput;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.*;
+import java.io.ByteArrayInputStream;
+import java.io.InputStream;
+import java.util.List;
+
+import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.Mockito.*;
+import jakarta.ws.rs.core.MultivaluedHashMap;
+import jakarta.ws.rs.core.MultivaluedMap;
+import java.util.Map;
+import org.jboss.logging.Logger;
+
+@QuarkusTest
+public class FileStorageServiceTest {
+
+    @Inject
+    FileStorageService fileStorageService;
+
+    private static final String BUCKET_NAME = "test-bucket";
+
+    @BeforeAll
+    public static void setup() throws Exception {
+        try (MinioClient client = MinioClient.builder()
+                .endpoint("http://localhost:9000")
+                .credentials("minioadmin", "minioadminpassword")
+                .build()) {
+            boolean bucketExists = client.bucketExists(BucketExistsArgs.builder().bucket(BUCKET_NAME).build());
+
+            if (!bucketExists) {
+                client.makeBucket(MakeBucketArgs.builder().bucket(BUCKET_NAME).build());
+            }
+        }
+    }
+
+    @AfterEach
+    public void cleanup() throws Exception {
+        Iterable<Result<Item>> results = fileStorageService.listObjects(BUCKET_NAME);
+        for (Result<Item> result : results) {
+            Item item = result.get();
+            fileStorageService.deleteObject(BUCKET_NAME, item.objectName());
+        }
+    }
+    @Test
+    public void testUploadFile_SUCCESS() throws Exception {
+        String fileName = "test-image.png";
+        String contentType = "image/png";
+        byte[] fileContent = "dummy image content".getBytes();
+
+        MultipartFormDataInput input = createMultipartFormDataInput(fileName, contentType, fileContent);
+        String fileUrl = fileStorageService.uploadFile(BUCKET_NAME, input);
+
+        assertNotNull(fileUrl, "File URL should not be null after successful upload");
+        boolean fileFound = false;
+        for (Result<Item> result : fileStorageService.listObjects(BUCKET_NAME)) {
+            Item item = result.get();
+            if (fileUrl.contains(item.objectName())) {
+                fileFound = true;
+                break;
+            }
+        }
+        assertTrue(fileFound, "Uploaded file should be found in the bucket");
+    }
+
+    @Test
+    public void testUploadFile_NoFilePart_Failure() throws Exception {
+        // Simulate a MultipartFormDataInput with no "file" entry
+        MultipartFormDataInput input = mock(MultipartFormDataInput.class);
+        when(input.getFormDataMap()).thenReturn(Map.of());
+
+        fileStorageService.logger = Logger.getLogger(FileStorageService.class);
+        MinioException thrown = Assertions.assertThrows(MinioException.class, () -> {
+            fileStorageService.uploadFile(BUCKET_NAME, input);
+        });
+        assertTrue(thrown.getMessage().contains("File is null or empty"));
+    }
+
+    @Test
+    public void testUploadFile_EmptyFilePart_Failure() throws Exception {
+        // Simulate a MultipartFormDataInput with empty file list
+        MultipartFormDataInput input = mock(MultipartFormDataInput.class);
+        when(input.getFormDataMap()).thenReturn(Map.of("file", List.of()));
+
+        fileStorageService.logger = Logger.getLogger(FileStorageService.class);
+        MinioException thrown = Assertions.assertThrows(MinioException.class, () -> {
+            fileStorageService.uploadFile(BUCKET_NAME, input);
+        });
+
+        assertTrue(thrown.getMessage().contains("File is null or empty"));
+    }
+
+    @Test
+    public void testUploadFile_InvalidContentType_Failure() throws Exception {
+        String fileName = "malicious.exe";
+        String contentType = "application/x-msdownload"; // not in allowedTypes
+        byte[] fileContent = "dummy content".getBytes();
+
+        MultipartFormDataInput input = createMultipartFormDataInput(fileName, contentType, fileContent);
+        fileStorageService.logger = Logger.getLogger(FileStorageService.class);
+        MinioException thrown = Assertions.assertThrows(MinioException.class, () -> {
+            fileStorageService.uploadFile(BUCKET_NAME, input);
+        });
+        assertTrue(thrown.getMessage().contains("Invalid file type"));
+    }
+
+    @Test
+    public void testUploadFile_BucketCreationFailure_Failure() throws Exception {
+        String fileName = "test.pdf";
+        String contentType = "application/pdf";
+        byte[] fileContent = "pdf content".getBytes();
+
+        MultipartFormDataInput input = createMultipartFormDataInput(fileName, contentType, fileContent);
+        MinioClient mockClient = mock(MinioClient.class);
+        // bucketExists forcibly returns false to trigger bucket creation
+        when(mockClient.bucketExists(any())).thenReturn(false);
+        // forcibly simulate a failure in makeBucket to see if the exception is thrown
+        doThrow(new RuntimeException("Bucket creation failed")).when(mockClient).makeBucket(any());
+
+        FileStorageService testService = new FileStorageService();
+        testService.minioClient = mockClient;
+        testService.endpoint = "http://localhost:9000";
+        testService.logger = Logger.getLogger(FileStorageService.class);
+        Exception thrown = Assertions.assertThrows(Exception.class, () -> {
+            testService.uploadFile("new-bucket", input);
+        });
+        assertTrue(thrown.getMessage().contains("Bucket creation failed"));
+    }
+
+    @Test
+    public void testUploadFile_UniqueNaming_SUCCESS() throws Exception {
+        String fileName = "test-image.png";
+        String contentType = "image/png";
+        byte[] fileContent = "dummy image content".getBytes();
+
+        MultipartFormDataInput input = createMultipartFormDataInput(fileName, contentType, fileContent);
+        String fileUrl = fileStorageService.uploadFile(BUCKET_NAME, input);
+        String fileUrl2 = fileStorageService.uploadFile(BUCKET_NAME, input);
+        assertNotEquals(fileUrl, fileUrl2);
+    }
+
+    @Test
+    public void testDownloadFile_Success() throws Exception {
+        String fileName = "test-download.txt";
+        String contentType = "text/plain";
+        byte[] fileContent = "This is some text".getBytes();
+        MultipartFormDataInput input = createMultipartFormDataInput(fileName, contentType, fileContent);
+        String fileUrl = fileStorageService.uploadFile(BUCKET_NAME, input);
+        assertNotNull(fileUrl);
+        try (InputStream downloaded = fileStorageService.downloadFile(BUCKET_NAME, fileName)) {
+            assertNotNull(downloaded, "Downloaded file input stream should not be null");
+            byte[] downloadedBytes = downloaded.readAllBytes();
+            assertTrue(new String(downloadedBytes).contains("This is some text"));
+        }
+    }
+
+    @Test
+    public void testDownloadFile_NotFound_Failure() throws Exception {
+        Exception thrown = Assertions.assertThrows(Exception.class, () -> {
+            fileStorageService.downloadFile(BUCKET_NAME, "non-existent-file.txt");
+        });
+        assertTrue(thrown.getMessage().contains("File does not exist"));
+    }
+
+    @Test
+    public void testGetContentType_Success() throws Exception {
+        String fileName = "content-type-test.pdf";
+        String contentType = "application/pdf";
+        byte[] fileContent = "Fake PDF content".getBytes();
+        MultipartFormDataInput input = createMultipartFormDataInput(fileName, contentType, fileContent);
+        fileStorageService.uploadFile(BUCKET_NAME, input);
+        String returnedContentType = fileStorageService.getContentType(BUCKET_NAME, fileName);
+        assertEquals("application/pdf", returnedContentType, "Content type should be application/pdf");
+    }
+
+    @Test
+    public void testGetContentType_NotFound_Failure() {
+        Exception thrown = Assertions.assertThrows(Exception.class, () -> {
+            fileStorageService.getContentType(BUCKET_NAME, "ghost-file.txt");
+        });
+        assertTrue(thrown.getMessage().contains("File does not exist"));
+    }
+
+
+
+    @Test
+    public void testListObjects_Success() throws Exception {
+        byte[] content = "some content".getBytes();
+        fileStorageService.uploadFile(BUCKET_NAME, createMultipartFormDataInput("file1.png", "image/png", content));
+        fileStorageService.uploadFile(BUCKET_NAME, createMultipartFormDataInput("file2.png", "image/png", content));
+
+        Iterable<Result<Item>> objects = fileStorageService.listObjects(BUCKET_NAME);
+        int count = 0;
+        for (Result<Item> r : objects) {
+            r.get();
+            count++;
+        }
+        assertTrue(count >= 2, "Should list at least two objects");
+    }
+
+    @Test
+    public void testListObjects_bucketNotFound_FAILURE() throws Exception {
+        MinioException thrown = Assertions.assertThrows(MinioException.class, () -> {
+            fileStorageService.listObjects("non-existent-bucket");
+        });
+        assertTrue(thrown.getMessage().contains("Bucket does not exist"));
+    }
+
+    @Test
+    public void testDeleteObject_Success() throws Exception {
+        String fileName = "file-to-delete.txt";
+        String contentType = "text/plain";
+        byte[] fileContent = "To be deleted".getBytes();
+        MultipartFormDataInput input = createMultipartFormDataInput(fileName, contentType, fileContent);
+        fileStorageService.uploadFile(BUCKET_NAME, input);
+
+        fileStorageService.deleteObject(BUCKET_NAME, fileName);
+
+        boolean found = false;
+        for (Result<Item> r : fileStorageService.listObjects(BUCKET_NAME)) {
+            if (r.get().objectName().equals(fileName)) {
+                found = true;
+                break;
+            }
+        }
+        assertFalse(found, "Object should have been deleted");
+    }
+
+    @Test
+    public void testDeleteObject_NotFound_FAILURE() throws Exception
+    {
+        String fileName = "non-existent-file.txt";
+        Exception thrown = Assertions.assertThrows(Exception.class, () -> {
+            fileStorageService.deleteObject(BUCKET_NAME, fileName);
+        });
+        assertTrue(thrown.getMessage().contains("File does not exist"));
+    }
+
+
+    private MultipartFormDataInput createMultipartFormDataInput(String fileName, String contentType, byte[] content)
+            throws Exception {
+        MultipartFormDataInput input = mock(MultipartFormDataInput.class);
+        InputPart inputPart = mock(InputPart.class);
+
+        MultivaluedMap<String, String> headers = new MultivaluedHashMap<>();
+        headers.add("Content-Disposition", "form-data; name=\"file\"; filename=\"" + fileName + "\"");
+
+        when(inputPart.getHeaders()).thenReturn(headers);
+        when(inputPart.getMediaType()).thenReturn(MediaType.valueOf(contentType));
+        when(inputPart.getBody(InputStream.class, null)).thenReturn(new ByteArrayInputStream(content));
+        when(input.getFormDataMap()).thenReturn(Map.of("file", List.of(inputPart)));
+
+        return input;
+    }
+
+
+
+}

--- a/remsfal-service/src/test/java/de/remsfal/service/control/FileStorageServiceTest.java
+++ b/remsfal-service/src/test/java/de/remsfal/service/control/FileStorageServiceTest.java
@@ -9,7 +9,6 @@ import jakarta.ws.rs.core.MediaType;
 import org.jboss.resteasy.plugins.providers.multipart.InputPart;
 import org.jboss.resteasy.plugins.providers.multipart.MultipartFormDataInput;
 import org.junit.jupiter.api.AfterEach;
-import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.*;
 import java.io.ByteArrayInputStream;
 import java.io.InputStream;
@@ -23,7 +22,6 @@ import java.util.Map;
 import org.jboss.logging.Logger;
 
 @QuarkusTest
-@TestInstance(TestInstance.Lifecycle.PER_CLASS)
 public class FileStorageServiceTest {
 
     @Inject
@@ -34,8 +32,8 @@ public class FileStorageServiceTest {
     @Inject
     MinioClient minioClient;
 
-    @BeforeAll
-    public void setup() throws Exception {
+    @BeforeEach
+    public void setup(){
         try {
             boolean bucketExists = minioClient.bucketExists(BucketExistsArgs.builder().bucket(BUCKET_NAME).build());
 

--- a/remsfal-service/src/test/java/de/remsfal/service/entity/ChatMessageRepositoryTest.java
+++ b/remsfal-service/src/test/java/de/remsfal/service/entity/ChatMessageRepositoryTest.java
@@ -218,10 +218,10 @@ class ChatMessageRepositoryTest extends AbstractTest {
     @Test
     @Transactional
     void sendImageChatMessage_SUCCESS() {
-        chatMessageRepository.sendChatMessage(CHAT_SESSION_ID, TestData.USER_ID_2, ChatMessageEntity.ContentType.IMAGE, "https://example.com/image.jpg");
+        chatMessageRepository.sendChatMessage(CHAT_SESSION_ID, TestData.USER_ID_2, ChatMessageEntity.ContentType.FILE, "https://example.com/image.jpg");
         ChatSessionEntity chatSession = chatSessionRepository.findChatSessionById(CHAT_SESSION_ID);
         assertEquals(2, chatSession.getMessages().size(), "Chat session should have 2 messages");
-        assertEquals("https://example.com/image.jpg", chatSession.getMessages().get(1).getImageUrl(),
+        assertEquals("https://example.com/image.jpg", chatSession.getMessages().get(1).getUrl(),
                 "Image URL of the second message should match");
     }
 
@@ -306,7 +306,7 @@ class ChatMessageRepositoryTest extends AbstractTest {
         assertEquals("Content cannot be null or empty", exception3.getMessage(),
                 "Exception message should match for blank content");
 
-        chatMessageRepository.sendChatMessage(CHAT_SESSION_ID, TestData.USER_ID_2, ChatMessageEntity.ContentType.IMAGE, "This is an image message");
+        chatMessageRepository.sendChatMessage(CHAT_SESSION_ID, TestData.USER_ID_2, ChatMessageEntity.ContentType.FILE, "This is an image message");
         String imageMessageId = chatSessionRepository.findChatSessionById(CHAT_SESSION_ID).getMessages().get(1).getId();
         Exception exception4 = assertThrows(IllegalArgumentException.class, () ->
                 chatMessageRepository.updateTextChatMessage(imageMessageId, validContent));
@@ -326,8 +326,8 @@ class ChatMessageRepositoryTest extends AbstractTest {
         chatMessage.setChatSession(chatSessionRepository.findChatSessionById(CHAT_SESSION_ID));
         chatMessage.setSender(sender);
         chatMessage.setSenderId(TestData.USER_ID_2);
-        chatMessage.setContentType(ChatMessageEntity.ContentType.IMAGE);
-        chatMessage.setImageUrl("https://example.com/image.jpg");
+        chatMessage.setContentType(ChatMessageEntity.ContentType.FILE);
+        chatMessage.setUrl("https://example.com/image.jpg");
         chatSessionRepository.findChatSessionById(CHAT_SESSION_ID).getMessages().add(chatMessage);
         chatMessageRepository.persist(chatMessage);
 
@@ -371,8 +371,8 @@ class ChatMessageRepositoryTest extends AbstractTest {
         chatMessage.setChatSession(chatSessionRepository.findChatSessionById(CHAT_SESSION_ID));
         chatMessage.setSender(sender);
         chatMessage.setSenderId(TestData.USER_ID_2);
-        chatMessage.setContentType(ChatMessageEntity.ContentType.IMAGE);
-        chatMessage.setImageUrl("https://example.com/image.jpg");
+        chatMessage.setContentType(ChatMessageEntity.ContentType.FILE);
+        chatMessage.setUrl("https://example.com/image.jpg");
         chatSessionRepository.findChatSessionById(CHAT_SESSION_ID).getMessages().add(chatMessage);
         chatMessageRepository.persist(chatMessage);
 

--- a/remsfal-service/src/test/java/de/remsfal/service/entity/ChatMessageRepositoryTest.java
+++ b/remsfal-service/src/test/java/de/remsfal/service/entity/ChatMessageRepositoryTest.java
@@ -208,17 +208,20 @@ class ChatMessageRepositoryTest extends AbstractTest {
     @Test
     @Transactional
     void sendTextChatMessage_SUCCESS() {
-        chatMessageRepository.sendChatMessage(CHAT_SESSION_ID, TestData.USER_ID_2, ChatMessageEntity.ContentType.TEXT, "This is a second test message");
+        chatMessageRepository.sendChatMessage(CHAT_SESSION_ID, TestData.USER_ID_2, ChatMessageEntity.ContentType.TEXT,
+                "This is a second test message");
         ChatSessionEntity chatSession = chatSessionRepository.findChatSessionById(CHAT_SESSION_ID);
         assertEquals(2, chatSession.getMessages().size(), "Chat session should have 2 messages");
         assertEquals("This is a second test message", chatSession.getMessages().get(1).getContent(),
                 "Content of the second message should match");
     }
 
+
     @Test
     @Transactional
-    void sendImageChatMessage_SUCCESS() {
-        chatMessageRepository.sendChatMessage(CHAT_SESSION_ID, TestData.USER_ID_2, ChatMessageEntity.ContentType.FILE, "https://example.com/image.jpg");
+    void sendFileMetadataChatMessage_SUCCESS() {
+        chatMessageRepository.sendChatMessage(CHAT_SESSION_ID, TestData.USER_ID_2, ChatMessageEntity.ContentType.FILE,
+                "https://example.com/image.jpg");
         ChatSessionEntity chatSession = chatSessionRepository.findChatSessionById(CHAT_SESSION_ID);
         assertEquals(2, chatSession.getMessages().size(), "Chat session should have 2 messages");
         assertEquals("https://example.com/image.jpg", chatSession.getMessages().get(1).getUrl(),
@@ -306,7 +309,8 @@ class ChatMessageRepositoryTest extends AbstractTest {
         assertEquals("Content cannot be null or empty", exception3.getMessage(),
                 "Exception message should match for blank content");
 
-        chatMessageRepository.sendChatMessage(CHAT_SESSION_ID, TestData.USER_ID_2, ChatMessageEntity.ContentType.FILE, "This is an image message");
+        chatMessageRepository.sendChatMessage(CHAT_SESSION_ID, TestData.USER_ID_2, ChatMessageEntity.ContentType.FILE,
+                "This is an image message");
         String imageMessageId = chatSessionRepository.findChatSessionById(CHAT_SESSION_ID).getMessages().get(1).getId();
         Exception exception4 = assertThrows(IllegalArgumentException.class, () ->
                 chatMessageRepository.updateTextChatMessage(imageMessageId, validContent));
@@ -397,7 +401,8 @@ class ChatMessageRepositoryTest extends AbstractTest {
 
         Exception exception4 = assertThrows(IllegalArgumentException.class, () ->
                 chatMessageRepository.updateImageURL(CHAT_MESSAGE_ID, validImageUrl));
-        assertEquals("Cannot update non-image message with updateImageURL() method", exception4.getMessage(), "Exception message should match for non-image message");
+        assertEquals("Cannot update non-image message with updateImageURL() method", exception4.getMessage(),
+                "Exception message should match for non-image message");
 
     }
 


### PR DESCRIPTION
# Integrate Minio for Enhanced File Storage Management
## Description:

Closes #259 

This PR introduces Minio as the primary file storage solution within the remsfal-service application. 

### Changes

#### File Storage Service
- ##### [Docker Compose Update](https://github.com/remsfal/remsfal-backend/pull/286/commits/bf7db6f6dd23d07996e1a4dc92dc96fd7aa03c87)
     - Added Minio Image: Incorporates the Minio container to facilitate file storage.

- ##### [File Storage Service](https://github.com/remsfal/remsfal-backend/pull/286/commits/a7c4a597b34df4c0dcd458b911bf5ecbfc651ae3)  
     - FileStorageService will handle all interactions with the Minio storage service. 
     - [Implemented FileStorageServiceTest to ensure all functionalities of the file storage service operate as expected, covering both success and failure scenarios.](https://github.com/remsfal/remsfal-backend/pull/286/commits/ec32eb88553003a4d0d462a1e7212d366ce912b3)

- ##### [Changes in Project Dependencies in remsfal-service](https://github.com/remsfal/remsfal-backend/pull/286/commits/91f90a54cbd85cca4aa2b4f8229fcb1bc1d64eff)
     - Quarkus-Minio Integration: Updated the pom.xml to include the quarkus-minio dependency, enabling Quarkus to interact effectively with the Minio service.

-  ##### [Configuration Updates](https://github.com/remsfal/remsfal-backend/pull/286/commits/53aa70a70f005f588f7db19e27f38998b252ac0d)
    - Application Properties: necessary Minio configurations

#### Integrate File Storage Service with Chat Service
##### [Changes in CHAT_MESSAGE Table and Model](https://github.com/remsfal/remsfal-backend/pull/286/commits/ada843fc5123fe4a2a15d0f108bafe49e165e201)
- change CONTENT_TYPE enums to TEXT and FILE (instead of IMAGE)
- changing the column IMAGE_URL to URL
##### [Implementation of Upload Endpoint in ChatEndpoint](https://github.com/remsfal/remsfal-backend/pull/286/commits/5054077b4901e9777a0f795b28b99b2afbe9e6b5)
- upload a file with a request on `/{sessionId}/messages/upload`
- supported file types are determined in FileStorageService allowedTypes
- the file itself will be uploaded to the bucket ("remsfal-chat-files") and the metadata (file URL, relevant chat session ID, chat message ID, project and user ID, etc.) will be saved on CHAT_MESSAGE table.
##### [Downloading Files in a Chat Session](https://github.com/remsfal/remsfal-backend/pull/286/commits/f13f5f4b1cd24fc184a63aad383d087363cf2710)
- no new endpoint needed, on `/{sessionId}/messages/{messageId}` based on the messageId it will be determined from the CHAT_MESSAGE table if it's a text message or a file. If it's a file, a MediaType.APPLICATION_OCTET_STREAM will be produced or the file will be downloaded.
