### PR TITLE
Potential fix for code scanning alert no. 55: Code injection

### DIFF
--- a/.github/workflows/sonar-analysis.yml
+++ b/.github/workflows/sonar-analysis.yml
@@ -77,10 +77,11 @@ jobs:
         id: pr_by_branch
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          HEAD_BRANCH: ${{ github.event.workflow_run.head_branch }}
         run: |
           pr_json=$(gh pr list \
             --repo "${{ github.event.workflow_run.repository.full_name }}" \
-            --head "${{ github.event.workflow_run.head_branch }}" \
+            --head "$HEAD_BRANCH" \
             --state all \
             --json number,headRefName,baseRefName \
             --limit 1)


### PR DESCRIPTION
Potential fix for [https://github.com/remsfal/remsfal-backend/security/code-scanning/55](https://github.com/remsfal/remsfal-backend/security/code-scanning/55)

To fix the problem, we need to prevent direct interpolation of potentially malicious user input into the shell command in the `run` section. Instead, we should pass the untrusted input to an environment variable via the `env:` block, then use shell syntax, referencing the variable in double quotes, within the shell script.

Specifically, in the step "Find Pull Request for Branch" (lines 75-92), change line 83 as follows:  
- Add an environment variable `HEAD_BRANCH: ${{ github.event.workflow_run.head_branch }}` under `env:` (around line 79).  
- Change line 83 in the shell script from `--head "${{ github.event.workflow_run.head_branch }}" \` to `--head "$HEAD_BRANCH" \`.

No additional methods, imports, or other changes are required.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
