### PR TITLE
Add integration tests for subresource initialization

### DIFF
--- a/remsfal-services/remsfal-platform/src/test/java/de/remsfal/service/boundary/ProjectResourceTest.java
+++ b/remsfal-services/remsfal-platform/src/test/java/de/remsfal/service/boundary/ProjectResourceTest.java
@@ -423,7 +423,7 @@ class ProjectResourceTest extends AbstractResourceTest {
             .body(containsString("deleteProjectTimer"));
     }
     @Test
-    void getApartmentResource_SUCCESS_resourceIsInitialized() {
+    void createApartmentResource_SUCCESS_resourceIsInitialized() {
         final String projectId = given()
                 .when()
                 .cookie(buildAccessTokenCookie(TestData.USER_ID, TestData.USER_EMAIL, Duration.ofMinutes(10)))
@@ -456,7 +456,7 @@ class ProjectResourceTest extends AbstractResourceTest {
     }
 
     @Test
-    void getCommercialResource_SUCCESS_resourceIsInitialized() {
+    void createCommercialResource_SUCCESS_resourceIsInitialized() {
         final String projectId = given()
                 .when()
                 .cookie(buildAccessTokenCookie(TestData.USER_ID, TestData.USER_EMAIL, Duration.ofMinutes(10)))
@@ -490,7 +490,7 @@ class ProjectResourceTest extends AbstractResourceTest {
     }
 
     @Test
-    void getStorageResource_SUCCESS_resourceIsInitialized() {
+    void createStorageResource_SUCCESS_resourceIsInitialized() {
         final String projectId = given()
                 .when()
                 .cookie(buildAccessTokenCookie(TestData.USER_ID, TestData.USER_EMAIL, Duration.ofMinutes(10)))


### PR DESCRIPTION
Add integration tests for subresource initialization

Added three integration tests to verify sub-resource locator methods 
are properly initialized:
- getApartmentResource_SUCCESS_resourceIsInitialized
- getCommercialResource_SUCCESS_resourceIsInitialized
- getStorageResource_SUCCESS_resourceIsInitialized

Tests create a project, building, and POST to each sub-resource endpoint, 
verifying status code 201 is returned.

Increases test coverage for ProjectResource as requested in SonarQube findings.