### PR TITLE
Potential fix for code scanning alert no. 58: Code injection

### DIFF
--- a/.github/workflows/sonar-analysis.yml
+++ b/.github/workflows/sonar-analysis.yml
@@ -95,12 +95,16 @@ jobs:
         env:
           SONAR_TOKEN: ${{ secrets.SONAR_TOKEN }}
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GITHUB_HEAD_SHA: ${{ github.event.workflow_run.head_sha }}
+          PR_NUMBER: ${{ steps.pr_by_branch.outputs.number }}
+          PR_HEAD_REF: ${{ steps.pr_by_branch.outputs.headRef }}
+          PR_BASE_REF: ${{ steps.pr_by_branch.outputs.baseRef }}
         run: |
           mvn sonar:sonar \
-            -Dsonar.scm.revision=${{ github.event.workflow_run.head_sha }} \
-            -Dsonar.pullrequest.key=${{ steps.pr_by_branch.outputs.number }} \
-            -Dsonar.pullrequest.branch=${{ steps.pr_by_branch.outputs.headRef }} \
-            -Dsonar.pullrequest.base=${{ steps.pr_by_branch.outputs.baseRef }}
+            -Dsonar.scm.revision="$GITHUB_HEAD_SHA" \
+            -Dsonar.pullrequest.key="$PR_NUMBER" \
+            -Dsonar.pullrequest.branch="$PR_HEAD_REF" \
+            -Dsonar.pullrequest.base="$PR_BASE_REF"
       # --- Sonar -> PUSH on main ---
       - name: SonarCloud Scan (main branch analysis)
         if: ${{ github.event.workflow_run.event == 'push' && github.event.workflow_run.head_branch == 'main' }}


### PR DESCRIPTION
Potential fix for [https://github.com/remsfal/remsfal-backend/security/code-scanning/58](https://github.com/remsfal/remsfal-backend/security/code-scanning/58)

In general, to fix this class of problem in GitHub Actions, avoid using `${{ ... }}` expressions directly inside `run:` scripts when they may contain any user-controlled data. Instead, assign the potentially tainted value to an environment variable via `env:` and then reference it inside the script using the shell’s native variable syntax (`$VAR`), or `process.env.VAR` for JavaScript. This prevents GitHub’s expression engine from performing interpolation within the shell script body and reduces the risk of command injection.

For this workflow, we only need to modify the **"SonarCloud Scan (PR decoration)"** step. Specifically:

- Add environment variables for the three PR-related outputs:
  - `PR_NUMBER: ${{ steps.pr_by_branch.outputs.number }}`
  - `PR_HEAD_REF: ${{ steps.pr_by_branch.outputs.headRef }}`
  - `PR_BASE_REF: ${{ steps.pr_by_branch.outputs.baseRef }}`
- Update the `mvn sonar:sonar` command to use standard shell variable references instead of `${{ ... }}`:
  - `-Dsonar.scm.revision="${GITHUB_HEAD_SHA}"` where `GITHUB_HEAD_SHA` is set from `${{ github.event.workflow_run.head_sha }}`
  - `-Dsonar.pullrequest.key="$PR_NUMBER"`
  - `-Dsonar.pullrequest.branch="$PR_HEAD_REF"`
  - `-Dsonar.pullrequest.base="$PR_BASE_REF"`
- Similarly, to fully align with best practices, we can also map `github.event.workflow_run.head_sha` into an env variable for this step (and optionally in the main-branch step) and reference it with shell syntax, even though CodeQL only flagged `baseRef`.

These edits are all within `.github/workflows/sonar-analysis.yml`; no new imports or external dependencies are necessary.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
