### PR TITLE
OrganizationMemberResource.java now fetches organization members and …

### DIFF
--- a/remsfal-services/remsfal-platform/src/main/java/de/remsfal/service/boundary/project/OrganizationMemberResource.java
+++ b/remsfal-services/remsfal-platform/src/main/java/de/remsfal/service/boundary/project/OrganizationMemberResource.java
@@ -31,10 +31,7 @@ public class OrganizationMemberResource extends AbstractProjectResource implemen
         final Set<? extends OrganizationMemberModel> organizations =
             controller.getProjectOrganizations(principal, projectId);
         final List<OrganizationMemberJson> result = organizations.stream()
-            .map(org -> OrganizationMemberJson.valueOf(org,
-                controller.getOrganizationMembers(org.getOrganizationId(), org.getRole()).stream()
-                    .map(ProjectMemberJson::valueOf)
-                    .collect(Collectors.toList())))
+            .map(org -> OrganizationMemberJson.valueOf(org, fetchMembers(org)))
             .collect(Collectors.toList());
         return OrganizationMemberListJson.valueOf(result);
     }
@@ -45,7 +42,7 @@ public class OrganizationMemberResource extends AbstractProjectResource implemen
         checkPropertyWritePermissions(projectId);
         final OrganizationMemberModel model =
             controller.addProjectOrganization(principal, projectId, organization);
-        return OrganizationMemberJson.valueOf(model);
+        return OrganizationMemberJson.valueOf(model, fetchMembers(model));
     }
 
     @Override
@@ -58,7 +55,13 @@ public class OrganizationMemberResource extends AbstractProjectResource implemen
         }
         final OrganizationMemberModel model = controller.changeProjectOrganizationRole(projectId,
             organizationId, organization.getRole());
-        return OrganizationMemberJson.valueOf(model);
+        return OrganizationMemberJson.valueOf(model, fetchMembers(model));
+    }
+
+    private List<ProjectMemberJson> fetchMembers(final OrganizationMemberModel organization) {
+        return controller.getOrganizationMembers(organization.getOrganizationId(), organization.getRole()).stream()
+            .map(ProjectMemberJson::valueOf)
+            .collect(Collectors.toList());
     }
 
     @Override

--- a/remsfal-services/remsfal-platform/src/test/java/de/remsfal/service/boundary/project/OrganizationMemberResourceTest.java
+++ b/remsfal-services/remsfal-platform/src/test/java/de/remsfal/service/boundary/project/OrganizationMemberResourceTest.java
@@ -225,7 +225,11 @@ class OrganizationMemberResourceTest extends AbstractResourceTest {
             .contentType(ContentType.JSON)
             .and().body("organizationId", Matchers.equalTo(TestData.ORGANIZATION_ID_2.toString()))
             .and().body("organizationName", Matchers.equalTo(TestData.ORGANIZATION_NAME_2))
-            .and().body("role", Matchers.equalTo("STAFF"));
+            .and().body("role", Matchers.equalTo("STAFF"))
+            .and().body("members.size()", Matchers.equalTo(1))
+            .and().body("members[0].id", Matchers.equalTo(TestData.USER_ID_1.toString()))
+            .and().body("members[0].email", Matchers.equalTo(TestData.USER_EMAIL_1))
+            .and().body("members[0].role", Matchers.equalTo("STAFF"));
     }
 
     @Test
@@ -245,7 +249,11 @@ class OrganizationMemberResourceTest extends AbstractResourceTest {
             .contentType(ContentType.JSON)
             .and().body("organizationId", Matchers.equalTo(TestData.ORGANIZATION_ID_2.toString()))
             .and().body("organizationName", Matchers.equalTo(TestData.ORGANIZATION_NAME_2))
-            .and().body("role", Matchers.equalTo("LESSOR"));
+            .and().body("role", Matchers.equalTo("LESSOR"))
+            .and().body("members.size()", Matchers.equalTo(1))
+            .and().body("members[0].id", Matchers.equalTo(TestData.USER_ID_1.toString()))
+            .and().body("members[0].email", Matchers.equalTo(TestData.USER_EMAIL_1))
+            .and().body("members[0].role", Matchers.equalTo("LESSOR"));
     }
 
     @Test
@@ -264,7 +272,11 @@ class OrganizationMemberResourceTest extends AbstractResourceTest {
             .contentType(ContentType.JSON)
             .and().body("organizationId", Matchers.equalTo(TestData.ORGANIZATION_ID.toString()))
             .and().body("organizationName", Matchers.equalTo(TestData.ORGANIZATION_NAME))
-            .and().body("role", Matchers.equalTo("MANAGER"));
+            .and().body("role", Matchers.equalTo("MANAGER"))
+            .and().body("members.size()", Matchers.equalTo(1))
+            .and().body("members[0].id", Matchers.equalTo(TestData.USER_ID_1.toString()))
+            .and().body("members[0].email", Matchers.equalTo(TestData.USER_EMAIL_1))
+            .and().body("members[0].role", Matchers.equalTo("MANAGER"));
     }
 
     @Test
@@ -284,7 +296,11 @@ class OrganizationMemberResourceTest extends AbstractResourceTest {
             .contentType(ContentType.JSON)
             .and().body("organizationId", Matchers.equalTo(TestData.ORGANIZATION_ID.toString()))
             .and().body("organizationName", Matchers.equalTo(TestData.ORGANIZATION_NAME))
-            .and().body("role", Matchers.equalTo("LESSOR"));
+            .and().body("role", Matchers.equalTo("LESSOR"))
+            .and().body("members.size()", Matchers.equalTo(1))
+            .and().body("members[0].id", Matchers.equalTo(TestData.USER_ID_1.toString()))
+            .and().body("members[0].email", Matchers.equalTo(TestData.USER_EMAIL_1))
+            .and().body("members[0].role", Matchers.equalTo("LESSOR"));
     }
 
     @Test

--- a/remsfal-services/remsfal-ticketing/src/main/java/de/remsfal/ticketing/boundary/eventing/InboxEventConsumer.java
+++ b/remsfal-services/remsfal-ticketing/src/main/java/de/remsfal/ticketing/boundary/eventing/InboxEventConsumer.java
@@ -4,6 +4,7 @@ import de.remsfal.core.json.eventing.IssueEventJson;
 import de.remsfal.ticketing.entity.dao.InboxMessageRepository;
 import de.remsfal.ticketing.entity.dto.InboxMessageEntity;
 import de.remsfal.ticketing.entity.dto.InboxMessageKey;
+import io.smallrye.common.annotation.Blocking;
 import jakarta.enterprise.context.ApplicationScoped;
 import jakarta.inject.Inject;
 import org.eclipse.microprofile.reactive.messaging.Incoming;
@@ -24,6 +25,7 @@ public class InboxEventConsumer {
     Logger logger;
 
     @Incoming(IssueEventJson.TOPIC_ENRICHED)
+    @Blocking
     public CompletionStage<Void> consume(Message<IssueEventJson> msg) {
 
         IssueEventJson event = msg.getPayload();

--- a/remsfal-services/remsfal-ticketing/src/main/java/de/remsfal/ticketing/control/IssueController.java
+++ b/remsfal-services/remsfal-ticketing/src/main/java/de/remsfal/ticketing/control/IssueController.java
@@ -122,6 +122,9 @@ public class IssueController {
         if (issue.getType() != null) {
             entity.setType(issue.getType());
         }
+        if (issue.getCategory() != null) {
+            entity.setCategory(issue.getCategory());
+        }
         if (issue.getStatus() != null) {
             entity.setStatus(issue.getStatus());
         }

--- a/remsfal-services/remsfal-ticketing/src/test/java/de/remsfal/ticketing/boundary/ProjectIssueResourceTest.java
+++ b/remsfal-services/remsfal-ticketing/src/test/java/de/remsfal/ticketing/boundary/ProjectIssueResourceTest.java
@@ -308,6 +308,49 @@ class ProjectIssueResourceTest extends AbstractTicketingTest {
     }
 
     @Test
+    void updateIssue_SUCCESS_categoryIsUpdated() {
+        final String createJson = "{ \"projectId\":\"" + TicketingTestData.PROJECT_ID + "\","
+            + "\"title\":\"" + TicketingTestData.ISSUE_TITLE + "\","
+            + "\"type\":\"DEFECT\""
+            + "}";
+
+        final Response createResponse = given()
+            .when()
+            .cookie(buildManagerCookie(TicketingTestData.MANAGER_PROJECT_ROLES))
+            .contentType(ContentType.JSON)
+            .body(createJson)
+            .post(BASE_PATH)
+            .thenReturn();
+
+        final String issueId = createResponse.then()
+            .contentType(MediaType.APPLICATION_JSON)
+            .extract().path("id");
+
+        final String updateJson = "{ \"category\":\"WATER_DAMAGE\" }";
+
+        given()
+            .when()
+            .cookie(buildManagerCookie(TicketingTestData.MANAGER_PROJECT_ROLES))
+            .contentType(ContentType.JSON)
+            .body(updateJson)
+            .patch(BASE_PATH + "/" + issueId)
+            .then()
+            .statusCode(200)
+            .contentType(ContentType.JSON)
+            .body("id", equalTo(issueId))
+            .body("category", equalTo("WATER_DAMAGE"));
+
+        given()
+            .when()
+            .cookie(buildManagerCookie(TicketingTestData.MANAGER_PROJECT_ROLES))
+            .get(BASE_PATH + "/" + issueId)
+            .then()
+            .statusCode(200)
+            .contentType(ContentType.JSON)
+            .body("category", equalTo("WATER_DAMAGE"));
+    }
+
+    @Test
     void updateIssue_FAILED_noAuthentication() {
         final String updateJson = "{ \"title\":\"Updated Title\" }";
 


### PR DESCRIPTION
…populates the members field on both POST (addProjectOrganization) and PATCH (updateProjectOrganization) responses, using the same lookup GET already used (extracted into a small fetchMembers helper to avoid duplication)