### PR TITLE
Erweiterung des Endpoints in RentalAgreements damit dieser den Tenant bearbeiten kann ohne den gesamten Rentalagreement zu benötigen.

### DIFF
--- a/remsfal-core/src/main/java/de/remsfal/core/api/project/RentalAgreementEndpoint.java
+++ b/remsfal-core/src/main/java/de/remsfal/core/api/project/RentalAgreementEndpoint.java
@@ -2,6 +2,7 @@ package de.remsfal.core.api.project;
 
 import de.remsfal.core.json.project.RentalAgreementJson;
 import de.remsfal.core.json.project.RentalAgreementListJson;
+import de.remsfal.core.json.project.TenantJson;
 import de.remsfal.core.validation.PatchValidation;
 import de.remsfal.core.validation.PostValidation;
 
@@ -96,4 +97,37 @@ public interface RentalAgreementEndpoint {
         @PathParam("projectId") @NotNull UUID projectId,
         @Parameter(description = "ID of the tenancy", required = true)
         @PathParam("agreementId") @NotNull UUID agreementId);
+
+    @POST
+    @Path("/{agreementId}/tenants")
+    @Consumes(MediaType.APPLICATION_JSON)
+    @Produces(MediaType.APPLICATION_JSON)
+    @Operation(summary = "Add a tenant to a rental agreement")
+    @APIResponse(responseCode = "201", description = "Tenant was added to the rental agreement successfully",
+        content = @Content(mediaType = MediaType.APPLICATION_JSON,
+            schema = @Schema(implementation = TenantJson.class)))
+    @APIResponse(responseCode = "400", description = "Invalid request message")
+    @APIResponse(responseCode = "401", description = "No user authentication provided via session cookie")
+    @APIResponse(responseCode = "404", description = "The rental agreement does not exist")
+    Response addTenant(
+        @Parameter(description = "ID of the project", required = true)
+        @PathParam("projectId") @NotNull UUID projectId,
+        @Parameter(description = "ID of the tenancy", required = true)
+        @PathParam("agreementId") @NotNull UUID agreementId,
+        @Parameter(description = "Tenant information", required = true)
+        @Valid @NotNull @ConvertGroup(to = PostValidation.class) TenantJson tenant);
+
+    @DELETE
+    @Path("/{agreementId}/tenants/{tenantId}")
+    @Operation(summary = "Remove a tenant from a rental agreement")
+    @APIResponse(responseCode = "204", description = "Tenant was removed from the rental agreement successfully")
+    @APIResponse(responseCode = "401", description = "No user authentication provided via session cookie")
+    @APIResponse(responseCode = "404", description = "The rental agreement does not exist")
+    void removeTenant(
+        @Parameter(description = "ID of the project", required = true)
+        @PathParam("projectId") @NotNull UUID projectId,
+        @Parameter(description = "ID of the tenancy", required = true)
+        @PathParam("agreementId") @NotNull UUID agreementId,
+        @Parameter(description = "ID of the tenant", required = true)
+        @PathParam("tenantId") @NotNull UUID tenantId);
 }

--- a/remsfal-services/remsfal-platform/src/main/java/de/remsfal/service/boundary/project/RentalAgreementResource.java
+++ b/remsfal-services/remsfal-platform/src/main/java/de/remsfal/service/boundary/project/RentalAgreementResource.java
@@ -13,7 +13,9 @@ import de.remsfal.core.api.project.RentalAgreementEndpoint;
 import de.remsfal.core.json.RentalUnitJson;
 import de.remsfal.core.json.project.RentalAgreementJson;
 import de.remsfal.core.json.project.RentalAgreementListJson;
+import de.remsfal.core.json.project.TenantJson;
 import de.remsfal.core.model.project.RentalAgreementModel;
+import de.remsfal.core.model.project.TenantModel;
 import de.remsfal.service.control.PropertyController;
 import de.remsfal.service.control.RentalAgreementController;
 
@@ -67,6 +69,22 @@ public class RentalAgreementResource extends AbstractProjectResource implements 
     public void deleteRentalAgreement(final UUID projectId, final UUID agreementId) {
         checkRentalAgreementWritePermissions(projectId);
         rentalAgreementController.deleteRentalAgreement(projectId, agreementId);
+    }
+
+    @Override
+    public Response addTenant(final UUID projectId, final UUID agreementId, final TenantJson tenant) {
+        checkRentalAgreementWritePermissions(projectId);
+        final TenantModel model = rentalAgreementController.addTenant(projectId, agreementId, tenant);
+        return getCreatedResponseBuilder(model.getId())
+            .type(MediaType.APPLICATION_JSON)
+            .entity(TenantJson.valueOf(model))
+            .build();
+    }
+
+    @Override
+    public void removeTenant(final UUID projectId, final UUID agreementId, final UUID tenantId) {
+        checkRentalAgreementWritePermissions(projectId);
+        rentalAgreementController.removeTenant(projectId, agreementId, tenantId);
     }
 
 }

--- a/remsfal-services/remsfal-platform/src/main/java/de/remsfal/service/control/RentalAgreementController.java
+++ b/remsfal-services/remsfal-platform/src/main/java/de/remsfal/service/control/RentalAgreementController.java
@@ -164,6 +164,34 @@ public class RentalAgreementController {
         return rentalAgreementRepository.merge(entity);
     }
 
+    @Transactional
+    public TenantEntity addTenant(final UUID projectId, final UUID agreementId, final TenantModel tenantInput) {
+        logger.infov("Adding a tenant to a rental agreement (projectId={0}, agreementId={1})",
+            projectId, agreementId);
+        final RentalAgreementEntity entity = rentalAgreementRepository
+            .findRentalAgreementByProject(projectId, agreementId)
+            .orElseThrow(() -> new NotFoundException("Rental agreement not exist"));
+
+        final TenantEntity tenant = processTenants(projectId, List.of(tenantInput)).get(0);
+        if (!entity.getTenants().contains(tenant)) {
+            entity.getTenants().add(tenant);
+        }
+        rentalAgreementRepository.merge(entity);
+        return tenant;
+    }
+
+    @Transactional
+    public void removeTenant(final UUID projectId, final UUID agreementId, final UUID tenantId) {
+        logger.infov("Removing a tenant from a rental agreement (projectId={0}, agreementId={1}, tenantId={2})",
+            projectId, agreementId, tenantId);
+        final RentalAgreementEntity entity = rentalAgreementRepository
+            .findRentalAgreementByProject(projectId, agreementId)
+            .orElseThrow(() -> new NotFoundException("Rental agreement not exist"));
+
+        entity.getTenants().removeIf(tenant -> tenant.getId().equals(tenantId));
+        rentalAgreementRepository.merge(entity);
+    }
+
     /**
      * Process tenant models and create or reuse tenant entities.
      * If a tenant matches an existing tenant in the project (based on business equality),

--- a/remsfal-services/remsfal-platform/src/main/java/de/remsfal/service/control/RentalAgreementController.java
+++ b/remsfal-services/remsfal-platform/src/main/java/de/remsfal/service/control/RentalAgreementController.java
@@ -173,9 +173,7 @@ public class RentalAgreementController {
             .orElseThrow(() -> new NotFoundException("Rental agreement not exist"));
 
         final TenantEntity tenant = processTenants(projectId, List.of(tenantInput)).get(0);
-        if (!entity.getTenants().contains(tenant)) {
-            entity.getTenants().add(tenant);
-        }
+        entity.addTenant(tenant);
         rentalAgreementRepository.merge(entity);
         return tenant;
     }
@@ -188,7 +186,7 @@ public class RentalAgreementController {
             .findRentalAgreementByProject(projectId, agreementId)
             .orElseThrow(() -> new NotFoundException("Rental agreement not exist"));
 
-        entity.getTenants().removeIf(tenant -> tenant.getId().equals(tenantId));
+        entity.removeTenant(tenantId);
         rentalAgreementRepository.merge(entity);
     }
 

--- a/remsfal-services/remsfal-platform/src/main/java/de/remsfal/service/entity/dto/RentalAgreementEntity.java
+++ b/remsfal-services/remsfal-platform/src/main/java/de/remsfal/service/entity/dto/RentalAgreementEntity.java
@@ -91,6 +91,16 @@ public class RentalAgreementEntity extends AbstractEntity implements RentalAgree
         this.tenants = tenants;
     }
 
+    public void addTenant(final TenantEntity tenant) {
+        if (!this.tenants.contains(tenant)) {
+            this.tenants.add(tenant);
+        }
+    }
+
+    public void removeTenant(final UUID tenantId) {
+        this.tenants.removeIf(tenant -> tenant.getId().equals(tenantId));
+    }
+
     @Override
     public LocalDate getStartOfRental() {
         return startOfRental;

--- a/remsfal-services/remsfal-platform/src/test/java/de/remsfal/service/boundary/project/RentalAgreementResourceTest.java
+++ b/remsfal-services/remsfal-platform/src/test/java/de/remsfal/service/boundary/project/RentalAgreementResourceTest.java
@@ -20,6 +20,8 @@ class RentalAgreementResourceTest extends AbstractResourceTest {
 
     static final String BASE_PATH = "/api/v1/projects/{projectId}/rental-agreements";
     static final String AGREEMENT_PATH = BASE_PATH + "/{agreementId}";
+    static final String AGREEMENT_TENANTS_PATH = AGREEMENT_PATH + "/tenants";
+    static final String AGREEMENT_TENANT_PATH = AGREEMENT_TENANTS_PATH + "/{tenantId}";
 
     @BeforeEach
     protected void setupTests() {
@@ -550,5 +552,124 @@ class RentalAgreementResourceTest extends AbstractResourceTest {
             .delete(AGREEMENT_PATH, TestData.PROJECT_ID.toString(), TestData.AGREEMENT_ID.toString())
             .then()
             .statusCode(Status.NO_CONTENT.getStatusCode());
+    }
+
+    @Test
+    void addTenant_SUCCESS_tenantAddedToAgreement() {
+        String json = "{\"firstName\":\"Max\", \"lastName\":\"Mustermann\"}";
+
+        given()
+            .when()
+            .cookie(buildAccessTokenCookie(TestData.USER_ID_1, TestData.USER_EMAIL_1, Duration.ofMinutes(10)))
+            .contentType(MediaType.APPLICATION_JSON)
+            .body(json)
+            .post(AGREEMENT_TENANTS_PATH, TestData.PROJECT_ID.toString(), TestData.AGREEMENT_ID.toString())
+            .then()
+            .log().ifValidationFails()
+            .statusCode(Status.CREATED.getStatusCode())
+            .header("Location", Matchers.notNullValue())
+            .body("id", Matchers.notNullValue())
+            .body("firstName", Matchers.equalTo("Max"))
+            .body("lastName", Matchers.equalTo("Mustermann"));
+
+        given()
+            .when()
+            .cookie(buildAccessTokenCookie(TestData.USER_ID_1, TestData.USER_EMAIL_1, Duration.ofMinutes(10)))
+            .get(AGREEMENT_PATH, TestData.PROJECT_ID.toString(), TestData.AGREEMENT_ID.toString())
+            .then()
+            .statusCode(Status.OK.getStatusCode())
+            .body("tenants.size()", Matchers.equalTo(1));
+    }
+
+    @Test
+    void addTenant_FAILURE_missingLastName() {
+        String json = "{\"firstName\":\"Max\"}";
+
+        given()
+            .when()
+            .cookie(buildAccessTokenCookie(TestData.USER_ID_1, TestData.USER_EMAIL_1, Duration.ofMinutes(10)))
+            .contentType(MediaType.APPLICATION_JSON)
+            .body(json)
+            .post(AGREEMENT_TENANTS_PATH, TestData.PROJECT_ID.toString(), TestData.AGREEMENT_ID.toString())
+            .then()
+            .statusCode(Status.BAD_REQUEST.getStatusCode());
+    }
+
+    @Test
+    void addTenant_FAILURE_agreementNotFound() {
+        String json = "{\"firstName\":\"Max\", \"lastName\":\"Mustermann\"}";
+
+        given()
+            .when()
+            .cookie(buildAccessTokenCookie(TestData.USER_ID_1, TestData.USER_EMAIL_1, Duration.ofMinutes(10)))
+            .contentType(MediaType.APPLICATION_JSON)
+            .body(json)
+            .post(AGREEMENT_TENANTS_PATH, TestData.PROJECT_ID.toString(), UUID.randomUUID().toString())
+            .then()
+            .statusCode(Status.NOT_FOUND.getStatusCode());
+    }
+
+    @Test
+    void addTenant_FAILURE_unauthorized() {
+        String json = "{\"firstName\":\"Max\", \"lastName\":\"Mustermann\"}";
+
+        given()
+            .when()
+            .cookie(buildAccessTokenCookie(TestData.USER_ID_2, TestData.USER_EMAIL_2, Duration.ofMinutes(10)))
+            .contentType(MediaType.APPLICATION_JSON)
+            .body(json)
+            .post(AGREEMENT_TENANTS_PATH, TestData.PROJECT_ID.toString(), TestData.AGREEMENT_ID.toString())
+            .then()
+            .statusCode(Status.FORBIDDEN.getStatusCode());
+    }
+
+    @Test
+    void removeTenant_SUCCESS_tenantRemovedFromAgreement() {
+        String tenantId = given()
+            .when()
+            .cookie(buildAccessTokenCookie(TestData.USER_ID_1, TestData.USER_EMAIL_1, Duration.ofMinutes(10)))
+            .contentType(MediaType.APPLICATION_JSON)
+            .body("{\"firstName\":\"Max\", \"lastName\":\"Mustermann\"}")
+            .post(AGREEMENT_TENANTS_PATH, TestData.PROJECT_ID.toString(), TestData.AGREEMENT_ID.toString())
+            .then()
+            .statusCode(Status.CREATED.getStatusCode())
+            .extract().path("id");
+
+        given()
+            .when()
+            .cookie(buildAccessTokenCookie(TestData.USER_ID_1, TestData.USER_EMAIL_1, Duration.ofMinutes(10)))
+            .delete(AGREEMENT_TENANT_PATH, TestData.PROJECT_ID.toString(), TestData.AGREEMENT_ID.toString(), tenantId)
+            .then()
+            .statusCode(Status.NO_CONTENT.getStatusCode());
+
+        given()
+            .when()
+            .cookie(buildAccessTokenCookie(TestData.USER_ID_1, TestData.USER_EMAIL_1, Duration.ofMinutes(10)))
+            .get(AGREEMENT_PATH, TestData.PROJECT_ID.toString(), TestData.AGREEMENT_ID.toString())
+            .then()
+            .statusCode(Status.OK.getStatusCode())
+            .body("tenants.size()", Matchers.equalTo(0));
+    }
+
+    @Test
+    void removeTenant_FAILURE_agreementNotFound() {
+        given()
+            .when()
+            .cookie(buildAccessTokenCookie(TestData.USER_ID_1, TestData.USER_EMAIL_1, Duration.ofMinutes(10)))
+            .delete(AGREEMENT_TENANT_PATH, TestData.PROJECT_ID.toString(), UUID.randomUUID().toString(),
+                UUID.randomUUID().toString())
+            .then()
+            .statusCode(Status.NOT_FOUND.getStatusCode());
+    }
+
+    @Test
+    void removeTenant_FAILURE_unauthorized() {
+        given()
+            .when()
+            .cookie(buildAccessTokenCookie(TestData.USER_ID_2, TestData.USER_EMAIL_2, Duration.ofMinutes(10)))
+            .delete(AGREEMENT_TENANT_PATH, TestData.PROJECT_ID.toString(), TestData.AGREEMENT_ID.toString(),
+                UUID.randomUUID().toString())
+            .then()
+            .statusCode(Status.FORBIDDEN.getStatusCode());
     }
 }

--- a/remsfal-services/remsfal-platform/src/test/java/de/remsfal/service/control/RentalAgreementControllerTest.java
+++ b/remsfal-services/remsfal-platform/src/test/java/de/remsfal/service/control/RentalAgreementControllerTest.java
@@ -8,6 +8,7 @@ import de.remsfal.core.json.project.RentalAgreementJson;
 import de.remsfal.core.json.project.ImmutableRentalAgreementJson;
 import de.remsfal.core.model.project.RentModel;
 import de.remsfal.service.entity.dto.RentalAgreementEntity;
+import de.remsfal.service.entity.dto.TenantEntity;
 import io.quarkus.test.junit.QuarkusTest;
 
 import jakarta.inject.Inject;
@@ -892,5 +893,122 @@ class RentalAgreementControllerTest extends AbstractServiceTest {
 
         RentalAgreementEntity entity = entityManager.find( RentalAgreementEntity.class, created.getId() );
         assertNull(entity);
+    }
+
+    @Test
+    void addTenant_SUCCESS_tenantAdded() {
+        final UUID projectId = TestData.PROJECT_ID_1;
+        final RentalAgreementJson agreement = ImmutableRentalAgreementJson.builder()
+            .startOfRental(LocalDate.now())
+            .tenants(List.of())
+            .build();
+        RentalAgreementEntity created = controller.createRentalAgreement(projectId, agreement);
+
+        final TenantJson tenant = ImmutableTenantJson.builder()
+            .firstName(TestData.USER_FIRST_NAME_1)
+            .lastName(TestData.USER_LAST_NAME_1)
+            .email(TestData.USER_EMAIL_1)
+            .build();
+
+        TenantEntity addedTenant =
+            controller.addTenant(projectId, created.getId(), tenant);
+
+        assertNotNull(addedTenant.getId());
+        assertEquals(TestData.USER_EMAIL_1, addedTenant.getEmail());
+
+        RentalAgreementEntity entity = entityManager.find(RentalAgreementEntity.class, created.getId());
+        assertEquals(1, entity.getTenants().size());
+        assertEquals(addedTenant.getId(), entity.getTenants().get(0).getId());
+    }
+
+    @Test
+    void addTenant_SUCCESS_reusesExistingTenantAcrossAgreements() {
+        final UUID projectId = TestData.PROJECT_ID_1;
+        final TenantJson tenant = ImmutableTenantJson.builder()
+            .firstName("Max")
+            .lastName("Schmidt")
+            .email("max.schmidt@example.com")
+            .build();
+
+        final RentalAgreementJson agreement1 = ImmutableRentalAgreementJson.builder()
+            .startOfRental(LocalDate.now())
+            .addTenants(tenant)
+            .build();
+        RentalAgreementEntity created1 = controller.createRentalAgreement(projectId, agreement1);
+        final UUID firstTenantId = created1.getTenants().get(0).getId();
+
+        final RentalAgreementJson agreement2 = ImmutableRentalAgreementJson.builder()
+            .startOfRental(LocalDate.now())
+            .tenants(List.of())
+            .build();
+        RentalAgreementEntity created2 = controller.createRentalAgreement(projectId, agreement2);
+
+        TenantEntity addedTenant =
+            controller.addTenant(projectId, created2.getId(), tenant);
+
+        assertEquals(firstTenantId, addedTenant.getId());
+    }
+
+    @Test
+    void addTenant_FAILED_agreementNotFound() {
+        final UUID projectId = TestData.PROJECT_ID_1;
+        final UUID agreementId = UUID.randomUUID();
+        final TenantJson tenant = ImmutableTenantJson.builder()
+            .firstName("Max")
+            .lastName("Mustermann")
+            .build();
+
+        assertThrows(NotFoundException.class,
+            () -> controller.addTenant(projectId, agreementId, tenant));
+    }
+
+    @Test
+    void removeTenant_SUCCESS_tenantRemovedFromAgreement() {
+        final UUID projectId = TestData.PROJECT_ID_1;
+        final TenantJson tenant = ImmutableTenantJson.builder()
+            .firstName(TestData.USER_FIRST_NAME_1)
+            .lastName(TestData.USER_LAST_NAME_1)
+            .email(TestData.USER_EMAIL_1)
+            .build();
+        final RentalAgreementJson agreement = ImmutableRentalAgreementJson.builder()
+            .startOfRental(LocalDate.now())
+            .addTenants(tenant)
+            .build();
+        RentalAgreementEntity created = controller.createRentalAgreement(projectId, agreement);
+        final UUID tenantId = created.getTenants().get(0).getId();
+
+        controller.removeTenant(projectId, created.getId(), tenantId);
+
+        RentalAgreementEntity entity = entityManager.find(RentalAgreementEntity.class, created.getId());
+        assertEquals(0, entity.getTenants().size());
+
+        // The tenant itself is not deleted, only detached from this agreement
+        TenantEntity tenantEntity =
+            entityManager.find(TenantEntity.class, tenantId);
+        assertNotNull(tenantEntity);
+    }
+
+    @Test
+    void removeTenant_SUCCESS_noOpWhenTenantNotInAgreement() {
+        final UUID projectId = TestData.PROJECT_ID_1;
+        final RentalAgreementJson agreement = ImmutableRentalAgreementJson.builder()
+            .startOfRental(LocalDate.now())
+            .tenants(List.of())
+            .build();
+        RentalAgreementEntity created = controller.createRentalAgreement(projectId, agreement);
+
+        controller.removeTenant(projectId, created.getId(), UUID.randomUUID());
+
+        RentalAgreementEntity entity = entityManager.find(RentalAgreementEntity.class, created.getId());
+        assertEquals(0, entity.getTenants().size());
+    }
+
+    @Test
+    void removeTenant_FAILED_agreementNotFound() {
+        final UUID projectId = TestData.PROJECT_ID_1;
+        final UUID agreementId = UUID.randomUUID();
+
+        assertThrows(NotFoundException.class,
+            () -> controller.removeTenant(projectId, agreementId, UUID.randomUUID()));
     }
 }

--- a/remsfal-services/remsfal-platform/src/test/java/de/remsfal/service/control/RentalAgreementControllerTest.java
+++ b/remsfal-services/remsfal-platform/src/test/java/de/remsfal/service/control/RentalAgreementControllerTest.java
@@ -1007,8 +1007,9 @@ class RentalAgreementControllerTest extends AbstractServiceTest {
     void removeTenant_FAILED_agreementNotFound() {
         final UUID projectId = TestData.PROJECT_ID_1;
         final UUID agreementId = UUID.randomUUID();
+        final UUID tenantId = UUID.randomUUID();
 
         assertThrows(NotFoundException.class,
-            () -> controller.removeTenant(projectId, agreementId, UUID.randomUUID()));
+            () -> controller.removeTenant(projectId, agreementId, tenantId));
     }
 }


### PR DESCRIPTION
Zwei neue Methoden Delete und Post